### PR TITLE
Prevent auto load of lodash.compat, closes #110

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -143,7 +143,8 @@ module.exports = function (grunt) {
     'bower-install': {
       app: {
         html: '<%= yeoman.app %>/index.html',
-        ignorePath: '<%= yeoman.app %>/'
+        ignorePath: '<%= yeoman.app %>/',
+        exclude: ['bower_components/lodash/dist/lodash.compat.js']
       }
     },
 

--- a/app/index.html
+++ b/app/index.html
@@ -191,6 +191,8 @@
     </div>
 </footer>
     <!-- build:js scripts/vendor.js -->
+    <!-- Manual reference to prevent CSP error, see #110 -->
+    <script src="bower_components/lodash/dist/lodash.js"></script>
     <!-- bower:js -->
     <script src="bower_components/jquery/jquery.js"></script>
     <script src="bower_components/es5-shim/es5-shim.js"></script>
@@ -201,7 +203,6 @@
     <script src="bower_components/angular-cookies/angular-cookies.js"></script>
     <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
     <script src="bower_components/angular-route/angular-route.js"></script>
-    <script src="bower_components/lodash/dist/lodash.js"></script>
     <script src="bower_components/restangular/dist/restangular.min.js"></script>
     <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
     <script src="bower_components/ng-table/ng-table.js"></script>


### PR DESCRIPTION
Lo-dash is a Restangular dependency. grunt-bower-install references
`lodash.compat.js` (as specified by its `main` property in `bower.json`),
which is non-CSP compliant.

Therefore, blacklist Lo-dash from grunt-bower-install and add the reference
manually (before Restangular to prevent possible loading issues and before
`bower:js` block which gets overwritten by grunt-bower-install).
