### PR TITLE
Use fa 4.0.4-wip branch to, see #113

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -11,8 +11,8 @@
     <!-- bower:css -->
     <link rel="stylesheet" href="bower_components/bootstrap/dist/css/bootstrap.css" />
     <link rel="stylesheet" href="bower_components/ng-table/ng-table.css" />
+    <link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.css" />
     <!-- endbower -->
-    <link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.min.css">
     <!-- endbuild -->
     <!-- build:css({.tmp,app}) styles/main.css -->
     <link rel="stylesheet" href="Ebro/css/style.css">

--- a/bower.json
+++ b/bower.json
@@ -14,13 +14,14 @@
     "restangular": "~1.2.2",
     "angular-bootstrap": "~0.10.0",
     "ng-table": "~0.3.1",
-    "font-awesome": "~4.0.3"
+    "font-awesome": "https://github.com/FortAwesome/Font-Awesome.git#4.0.4-wip"
   },
   "devDependencies": {
     "angular-mocks": "1.2.6",
     "angular-scenario": "1.2.6"
   },
   "resolutions": {
-    "angular": "=1.2.6"
+    "angular": "=1.2.6",
+    "font-awesome": "4.0.4-wip"
   }
 }


### PR DESCRIPTION
Font Awesome master uses `component.json` instead of `bower.json`, which trips
up `grunt-bower-install`.

See: https://github.com/FortAwesome/Font-Awesome/pull/2344
