### PR TITLE
Explicitly use components/jquery

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "angular": "1.2.12",
     "json3": "3.3.0",
     "es5-shim": "2.3.0",
-    "jquery": "2.1.0",
+    "jquery": "components/jquery#2.1.0",
     "bootstrap": "3.0.3",
     "angular-resource": "1.2.12",
     "angular-cookies": "1.2.12",


### PR DESCRIPTION
jquery used to be a shorthand for components/jquery, while jQuery referred to
jquery/jquery.

Recently the jQuery team requested that jquery point to jquery/jquery as well.

Bugs are now open with both projects:

http://bugs.jquery.com/ticket/14798
https://github.com/bower/bower/issues/1118

Until this issue is resolved, we should be explicit about what version we
want.
