### PR TITLE
Start app maximised, closes #171

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -1,17 +1,10 @@
 'use strict';
 
 // Listens for the app launching then creates the window
+// @see https://developer.chrome.com/apps/app_window
 chrome.app.runtime.onLaunched.addListener(function() {
-    var width = 500;
-    var height = 300;
-
-    chrome.app.window.create('index.html', {
-        id: 'main',
-        bounds: {
-            width: width,
-            height: height,
-            left: Math.round((screen.availWidth - width) / 2),
-            top: Math.round((screen.availHeight - height)/2)
-        }
-    });
+  chrome.app.window.create('index.html', {
+    id: 'main',
+    state: 'maximized'
+  });
 });


### PR DESCRIPTION
Simplify bounds and start maximised by default, preserving `id` so that if the
user does resize the window, it's preserved between restarts.
