### PR TITLE
Bind alert message on a nested span, closes #208

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -30,9 +30,10 @@
 
   <section class="container clearfix main_section">
     <div id="main_content_outer" class="clearfix">
-      <alert ng-repeat="alert in alerts"
-             type="alert.type" close="closeAlert($index)"
-             ng-bind="alert.message"></alert>
+      <alert ng-repeat="alert in alerts" type="alert.type"
+        close="closeAlert($index)">
+        <span ng-bind="alert.message"></span>
+      </alert>
 
       <tv-breadcrumbs ng-hide="$state.includes('home')"
         home="home.index.controlPanel"></tv-breadcrumbs>


### PR DESCRIPTION
The `alert` directive has `replace: true`, which removes the initial DOM
element and hence cause the binding to fail.
