### PR TITLE
Adds test coverage reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ app/bower_components
 .idea/
 npm-debug.log
 test/bower_components
+coverage

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -293,6 +293,15 @@ module.exports = function(grunt) {
       e2e: {
         configFile: 'protractor.conf.js'
       }
+    },
+
+    coveralls: {
+      options: {
+        debug: true,
+        // jshint camelcase: false
+        coverage_dir: 'coverage',
+        dryRun: true,
+      }
     }
   });
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -297,10 +297,8 @@ module.exports = function(grunt) {
 
     coveralls: {
       options: {
-        debug: true,
         // jshint camelcase: false
-        coverage_dir: 'coverage',
-        dryRun: true,
+        coverage_dir: 'coverage'
       }
     }
   });
@@ -325,7 +323,8 @@ module.exports = function(grunt) {
     'concurrent:test',
     'autoprefixer',
     'connect:test',
-    'karma'
+    'karma',
+    'coveralls'
   ]);
 
   grunt.registerTask('build', [

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # LMIS-Chrome
 
-[![Build Status][travis-image]][travis-url] [![devDependency Status][daviddm-image]][daviddm-url]
+[![Build Status][travis-image]][travis-url] [![devDependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
 
 [travis-url]: https://travis-ci.org/eHealthAfrica/LMIS-Chrome
 [travis-image]: https://travis-ci.org/eHealthAfrica/LMIS-Chrome.png?branch=master
 [daviddm-url]: https://david-dm.org/eHealthAfrica/LMIS-Chrome#info=devDependencies
 [daviddm-image]: https://david-dm.org/eHealthAfrica/LMIS-Chrome/dev-status.png?theme=shields.io
+[coveralls-url]: https://coveralls.io/r/eHealthAfrica/LMIS-Chrome
+[coveralls-image]: https://coveralls.io/repos/eHealthAfrica/LMIS-Chrome/badge.png
 
 > LMIS Chrome packaged app
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -28,7 +28,6 @@ module.exports = function(config) {
       'app/bower_components/angular-translate-loader-static-files/angular-translate-loader-static-files.js',
       'app/bower_components/angular-translate-storage-cookie/angular-translate-storage-cookie.js',
       'app/bower_components/angular-toggle-switch/angular-toggle-switch.js',
-      'app/scripts/*.js',
       'app/scripts/**/*.js',
       'test/mock/**/*.js',
       'test/spec/**/*.js'
@@ -61,6 +60,22 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit
-    singleRun: false
+    singleRun: false,
+
+    // grunt-karma-coveralls
+    reporters: [
+      'progress',
+      'coverage'
+    ],
+    preprocessors: {
+      'app/scripts/**/*.js': 'coverage'
+    },
+    coverageReporter: {
+      type: 'lcov',
+      dir: 'coverage'
+    },
+    plugins: [
+      'karma-*'
+    ]
   });
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "karma-phantomjs-launcher": "~0.1.2",
     "change-case": "~1.0.6",
     "cli-prompt": "~0.3.2",
-    "grunt-protractor-runner": "^0.2.3"
+    "grunt-protractor-runner": "^0.2.3",
+    "grunt-karma-coveralls": "^2.4.0",
+    "karma-coverage": "^0.2.0"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
Run `grunt test` and see:

```
open coverage/PhantomJS*/lcov-report/index.html
```

Example coveralls output:

https://coveralls.io/builds/570581
