### PR TITLE
Move coveralls into a Travis-only task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -284,8 +284,7 @@ module.exports = function(grunt) {
     // Test settings
     karma: {
       unit: {
-        configFile: 'karma.conf.js',
-        singleRun: true
+        configFile: 'karma.conf.js'
       }
     },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -317,14 +317,22 @@ module.exports = function(grunt) {
     ]);
   });
 
-  grunt.registerTask('test', [
-    'clean:server',
-    'concurrent:test',
-    'autoprefixer',
-    'connect:test',
-    'karma',
-    'coveralls'
-  ]);
+  grunt.registerTask('test', function(target) {
+    if (target === 'unit') {
+      return grunt.task.run(['karma:unit']);
+    }
+    else if (target === 'e2e') {
+      return grunt.task.run(['protractor:e2e']);
+    }
+
+    grunt.task.run([
+      'clean:server',
+      'concurrent:test',
+      'autoprefixer',
+      'connect:test',
+      'karma'
+    ]);
+  });
 
   grunt.registerTask('build', [
     'clean:dist',
@@ -348,4 +356,11 @@ module.exports = function(grunt) {
     'test',
     'build'
   ]);
+
+  grunt.registerTask('travis', function() {
+    grunt.task.run([
+      'test',
+      'coveralls'
+    ]);
+  });
 };

--- a/README.md
+++ b/README.md
@@ -30,20 +30,23 @@
 
 ## Testing
 
+Use `grunt test` for the complete test suite. `npm test` is reserved for our
+continuous integration server (TravisCI).
+
 ### Unit
 
-Use `npm test` for the complete test suite. During development, `npm run-script
-test-watch` is useful to automatically re-run the tests when a file changes.
+Use `grunt test:unit`. During development, `npm run-script test-watch` is
+useful to automatically re-run the tests when a file changes.
 
 ### e2e
 
 1. Install selenium (one-time only):
 
-```bash
-./node_modules/grunt-protractor-runner/node_modules/protractor/bin/webdriver-manager update
-```
+    ```bash
+    ./node_modules/grunt-protractor-runner/node_modules/protractor/bin/webdriver-manager update
+    ```
 
-2. `grunt protractor:e2e`
+2. `grunt test:e2e`
 
 ## Author
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -60,7 +60,7 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, it capture browsers, run tests and exit
-    singleRun: false,
+    singleRun: true,
 
     // grunt-karma-coveralls
     reporters: [

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "node": "0.10.x"
   },
   "scripts": {
-    "test": "grunt test",
-    "test-watch": "./node_modules/karma/bin/karma start --autoWatch true",
+    "test": "grunt travis",
+    "test-watch": "./node_modules/.bin/karma start --autoWatch true --singleRun false",
     "translate": "node scripts/translate.js"
   },
   "description": "LMIS Chrome packaged app",


### PR DESCRIPTION
Since Travis calls `npm test`, keep it reserved for Travis and default it
to `grunt travis`.

Add optional targets to `grunt test` to call a specific suite (`grunt
test:unit`, `grunt test:e2e`).
