### PR TITLE
Removed extra scroll bar.

### DIFF
--- a/app/Ebro/css/style.css
+++ b/app/Ebro/css/style.css
@@ -1,5 +1,5 @@
-	html,body {height: 100%;max-width:100%;overflow-y: scroll;}
-	body {overflow-x:hidden}
+	html,body {height: 100%;max-width:100%;}
+	body {overflow-x:hidden;overflow-y: scroll;}
 	
 	a {color:#2992c8}
 	a:hover,a:focus {color:#056495}


### PR DESCRIPTION
See screenshot below. I get two scroll bars on the y-axis because overflow-y is being applied to both the html, and body tag.

![lmis-chrome-two-scrollbars](https://f.cloud.github.com/assets/126417/2345601/a6d7b23a-a537-11e3-8673-d25ff704b403.png)

If you look at the [Ebro theme](http://ebro-admin.tzdthemes.com/) it doesn't contain overflow-y on the html,body.
