### PR TITLE
Fix failing home spec, closes #107

### DIFF
--- a/test/spec/controllers/home.js
+++ b/test/spec/controllers/home.js
@@ -37,6 +37,7 @@ describe('Home controller', function () {
   it('should go to the main activity state', function() {
     var home = $state.get('home');
     home.resolve.currentFacility = function() { return {}; };
+    home.resolve.facilityLocation = function() { return {}; };
     $rootScope.$apply(function() {
       $state.go(state);
     });


### PR DESCRIPTION
Resolving the facility location was moved into the state's `resolve` block,
which was missing in the test.
