### PR TITLE
Revert "Regen and encrypt Flowdock key"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,4 @@ before_script:
   - 'npm install -g bower grunt-cli'
   - 'bower install'
 notifications:
-  flowdock:
-    secure: 'FdO2tCN2svozYRR5OAXTD9uctkYaxAU6pR9Oz8mnmOtsjbUszzzUFYFzWxm69hg2qfdFBxvdYAdPECOA2L0JTwWB3fLacG1rjU32bkj0VPQ+bePYkdZNk36occegA1a0AgI73DkruMrArDzNBOM+4PtMzThsuj9S+K8BwMOf/+0='
+  flowdock: 232485f7661e644ae5878944c2597042


### PR DESCRIPTION
Travis-Flowdock integration is currently broken. This worked before encrypting
the key, so revert to the insecure method until we can find a better method.

This reverts commit a57607430a3dd7daa39a18f7b4be253e08ce9691.
