### PR TITLE
Resolve batch after related fields have resolved

### DIFF
--- a/app/scripts/services/batchfactory.js
+++ b/app/scripts/services/batchfactory.js
@@ -7,24 +7,20 @@ angular.module('lmisChromeApp')
         var deferred = $q.defer();
 
         storageService.find(storageService.BATCH, uuid).then(function(batch) {
-          var promises = [
-            productTypeFactory.get(batch.product),
-            presentationFactory.get(batch.presentation),
-            companyFactory.get(batch.manufacturer),
-            currencyFactory.get(batch.price_currency),
-            modeOfAdministrationFactory.get(batch.mode_of_use),
-            formulationFactory.get(batch.formulation),
-            uomFactory.get(batch.volume_uom),
-          ];
+          var promises = {
+            product: productTypeFactory.get(batch.product),
+            presentation: presentationFactory.get(batch.presentation),
+            manufacturer: companyFactory.get(batch.manufacturer),
+            price_currency: currencyFactory.get(batch.price_currency),
+            mode_of_use: modeOfAdministrationFactory.get(batch.mode_of_use),
+            formulation: formulationFactory.get(batch.formulation),
+            volume_uom: uomFactory.get(batch.volume_uom)
+          };
 
-          $q.all(promises).then(function(results) {
-            batch.product = results[0];
-            batch.presentation = results[1];
-            batch.manufacturer = results[2];
-            batch.price_currency = results[3];
-            batch.mode_of_use = results[4];
-            batch.formulation = results[5];
-            batch.volume_uom = results[6];
+          $q.all(promises).then(function(result) {
+            for(var key in result) {
+              batch[key] = result[key];
+            }
             deferred.resolve(batch);
             if(!$rootScope.$$phase) {
               $rootScope.$apply();

--- a/app/scripts/services/inventoryfactory.js
+++ b/app/scripts/services/inventoryfactory.js
@@ -18,22 +18,19 @@ angular.module('lmisChromeApp')
               inventoryLine.batch = data;
             }
 
-            var promises = [
-              productTypeFactory.get(inventoryLine.product_type),
-              programsFactory.get(inventoryLine.program),
-              uomFactory.get(inventoryLine.uom),
-              facilityFactory.get(inventoryLine.receiving_facility),
-              facilityFactory.get(inventoryLine.sending_facility),
-              storageUnitFactory.get(inventoryLine.storage_unit)
-            ];
+            var promises = {
+              product_type: productTypeFactory.get(inventoryLine.product_type),
+              program: programsFactory.get(inventoryLine.program),
+              uom: uomFactory.get(inventoryLine.uom),
+              receiving_facility: facilityFactory.get(inventoryLine.receiving_facility),
+              sending_facility: facilityFactory.get(inventoryLine.sending_facility),
+              storage_unit: storageUnitFactory.get(inventoryLine.storage_unit)
+            };
 
             $q.all(promises).then(function(result) {
-              inventoryLine.product_type = result[0];
-              inventoryLine.program = result[1];
-              inventoryLine.uom = result[2];
-              inventoryLine.receiving_facility = result[3];
-              inventoryLine.sending_facility = result[4];
-              inventoryLine.storage_unit = result[5];
+              for(var key in result) {
+                inventoryLine[key] = result[key];
+              }
               deferred.resolve(inventoryLine);
             });
           });

--- a/app/scripts/services/inventoryfactory.js
+++ b/app/scripts/services/inventoryfactory.js
@@ -2,7 +2,7 @@
 // jshint camelcase: false
 
 angular.module('lmisChromeApp')
-  .factory('inventoryFactory', function($q, storageService, productTypeFactory, programsFactory, storageUnitFactory, batchFactory, facilityFactory, uomFactory, $timeout) {
+  .factory('inventoryFactory', function($q, storageService, productTypeFactory, programsFactory, storageUnitFactory, batchFactory, facilityFactory, uomFactory) {
 
     function getByUUID(uuid) {
       var deferred = $q.defer();
@@ -17,34 +17,27 @@ angular.module('lmisChromeApp')
             if(data.toString() === '[object Object]') {
               inventoryLine.batch = data;
             }
-          });
 
-          productTypeFactory.get(inventoryLine.product_type).then(function(data) {
-            inventoryLine.product_type = data;
-          });
+            var promises = [
+              productTypeFactory.get(inventoryLine.product_type),
+              programsFactory.get(inventoryLine.program),
+              uomFactory.get(inventoryLine.uom),
+              facilityFactory.get(inventoryLine.receiving_facility),
+              facilityFactory.get(inventoryLine.sending_facility),
+              storageUnitFactory.get(inventoryLine.storage_unit)
+            ];
 
-          programsFactory.get(inventoryLine.program).then(function(data) {
-            inventoryLine.program = data;
+            $q.all(promises).then(function(result) {
+              inventoryLine.product_type = result[0];
+              inventoryLine.program = result[1];
+              inventoryLine.uom = result[2];
+              inventoryLine.receiving_facility = result[3];
+              inventoryLine.sending_facility = result[4];
+              inventoryLine.storage_unit = result[5];
+              deferred.resolve(inventoryLine);
+            });
           });
-
-          uomFactory.get(inventoryLine.uom).then(function(data) {
-            inventoryLine.uom = data;
-          });
-
-          facilityFactory.get(inventoryLine.receiving_facility).then(function(data) {
-            inventoryLine.receiving_facility = data;
-          });
-
-          facilityFactory.get(inventoryLine.sending_facility).then(function(data) {
-            inventoryLine.sending_facility = data;
-          });
-
-          storageUnitFactory.get(inventoryLine.storage_unit).then(function(data) {
-            inventoryLine.storage_unit = data;
-          });
-
         }
-        deferred.resolve(inventoryLine);
       });
       return deferred.promise;
     }
@@ -98,8 +91,7 @@ angular.module('lmisChromeApp')
               }
               deferred.resolve(codes);
             };
-            // XXX: Need to wait until batch promise is settled (line 16)
-            $timeout(collateCodes, 1000);
+            collateCodes();
           });
         return deferred.promise;
       },


### PR DESCRIPTION
Previously, the batch promised was resolved before all of its associated
models had been loaded. This delays the resolve until everything has been
populated.

@jofomah, could you look over this one to see if I've missed anything? It
should also fix the inventory list "table repopulating" bug we noticed a while
ago.

See: https://www.flowdock.com/app/ehealth-africa/lomis/inbox/46825
