### PR TITLE
Bump grunt-karma-coveralls with status fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "karma-jasmine": "~0.1.5",
     "karma-phantomjs-launcher": "~0.1.2",
     "grunt-protractor-runner": "^0.2.3",
-    "grunt-karma-coveralls": "^2.4.0",
+    "grunt-karma-coveralls": "^2.4.3",
     "karma-coverage": "^0.2.0"
   },
   "engines": {


### PR DESCRIPTION
Upstream now handles coveralls downtime more gracefully.

Closes #118
