### PR TITLE
Move default state out of run block

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -58,7 +58,4 @@ angular.module('lmisChromeApp', [
 
       // Convenience property to get the current state
       $rootScope.$state = $state;
-
-      // Default state
-      $state.go('home.index.mainActivity');
     });

--- a/app/scripts/controllers/home.js
+++ b/app/scripts/controllers/home.js
@@ -1,9 +1,11 @@
 'use strict';
 
 angular.module('lmisChromeApp')
-  .config(function($stateProvider) {
+  .config(function($urlRouterProvider, $stateProvider) {
+    // Initial state
+    $urlRouterProvider.otherwise('/main-activity');
     $stateProvider.state('home', {
-      url: '/home',
+      url: '',
       abstract: true,
       templateUrl: 'views/home/index.html',
       resolve: {

--- a/test/spec/controllers/home.js
+++ b/test/spec/controllers/home.js
@@ -31,7 +31,7 @@ describe('Home controller', function () {
 
   var state = 'home.index.mainActivity';
   it('should respond to URL', function() {
-    expect($state.href(state)).toEqual('#/home/main-activity');
+    expect($state.href(state)).toEqual('#/main-activity');
   });
 
   it('should go to the main activity state', function() {

--- a/test/spec/services/alertsfactory.js
+++ b/test/spec/services/alertsfactory.js
@@ -100,13 +100,13 @@ describe('Service: alertsFactory', function() {
       scope.$apply(function() {
         $state.go(ma);
         alertsFactory.add({message: 'Test'});
+        expect(scope.alerts.length).toEqual(1);
       });
-      expect(scope.alerts.length).toEqual(1);
 
       scope.$apply(function() {
         $state.go(dash);
+        expect(scope.alerts.length).toEqual(0);
       });
-      expect(scope.alerts.length).toEqual(0);
     });
   });
 


### PR DESCRIPTION
`$scope.go()` inside the top-level run block will increase test complexity as
a mock template cache would need to be set up for each test that uses `$scope`
regardless of whether it depends on a template.

UI Router currently uses a state using an empty `url` as the default state,
see:

https://github.com/angular-ui/ui-router/issues/182
https://github.com/angular-ui/ui-router/issues/174#issuecomment-19330523

Since we're setting up the layout in a parent, abstract state, redirect to the
_real_ index using `otherwise()`.
