### PR TITLE
Replace alert calls with levels, deprecate add

### DIFF
--- a/app/scripts/controllers/bundle.js
+++ b/app/scripts/controllers/bundle.js
@@ -141,7 +141,7 @@ angular.module('lmisChromeApp').config(function ($stateProvider) {
             });
           }
         }, function (error) {
-          alertsFactory.add({message: error, type: 'danger'});
+          alertsFactory.danger(error);
           console.log(error);
         });
 

--- a/app/scripts/controllers/home.js
+++ b/app/scripts/controllers/home.js
@@ -59,12 +59,12 @@ angular.module('lmisChromeApp')
           $stateParams.orderNo = null;
           $translate('orderPlacedSuccess', {orderNo: $stateParams.orderNo})
             .then(function (msg) {
-              alertsFactory.add({message: msg, type: 'success'});
+              alertsFactory.success(msg);
             });
         }
 
         if($stateParams.stockResult !== null){
-          alertsFactory.add({message: $stateParams.stockResult, type: 'success'});
+          alertsFactory.success($stateParams.stockResult);
           $stateParams.stockResult = null;
         }
       }
@@ -162,18 +162,12 @@ angular.module('lmisChromeApp')
           settingsService.save(settings)
             .then(function() {
               $translate('settingsSaved').then(function(settingsSaved) {
-                alertsFactory.add({
-                  message: settingsSaved,
-                  type: 'success'
-                });
+                alertsFactory.success(settingsSaved);
               });
             })
             .catch(function() {
               $translate('settingsFailed').then(function(settingsFailed) {
-                alertsFactory.add({
-                  message: settingsFailed,
-                  type: 'danger'
-                });
+                alertsFactory.danger(settingsFailed);
               });
             });
         };

--- a/app/scripts/controllers/producttype.js
+++ b/app/scripts/controllers/producttype.js
@@ -80,20 +80,14 @@ angular.module('lmisChromeApp').config(function ($stateProvider) {
         if (Object.keys($scope.product).length > 0) {
           storageService.insert(storageService.PRODUCT_TYPES, $scope.product).then(function (bool) {
             if (bool) {
-              alertsFactory.add({
-                message: 'Data saved ',
-                type: 'success'
-              });
+              alertsFactory.success('Data saved');
               $location.path('/main/products');
             } else {
 
             }
           });
         } else {
-          alertsFactory.add({
-            message: 'can\'t save empty form',
-            type: 'danger'
-          });
+          alertsFactory.danger('can\'t save empty form');
         }
       };
     });

--- a/app/scripts/controllers/programs.js
+++ b/app/scripts/controllers/programs.js
@@ -24,20 +24,15 @@ angular.module('lmisChromeApp')
         storageService.insert(storageService.PROGRAM, $scope.program).then(
           function() {
             var msg = ($scope.uuid) ? {
-              type: 'success',
               message: 'Program update was successful'
             } : {
-              type: 'success',
               message: 'Program entry was successful'
             };
-            alertsFactory.add(msg);
+            alertsFactory.success(msg);
             $location.path('/main/programs');
           });
       } else {
-        alertsFactory.add({
-          type: 'danger',
-          message: 'Can\'t save a blank form'
-        });
+        alertsFactory.danger('Can\'t save a blank form');
       }
     };
 
@@ -114,21 +109,16 @@ angular.module('lmisChromeApp')
         storageService.insert(storageService.PROGRAM_PRODUCTS, $scope.program_product)
           .then(function() {
             var msg = ($scope.uuid) ? {
-              type: 'success',
               message: 'Program update was successful'
             } : {
-              type: 'success',
               message: 'Program entry was successful'
             };
-            alertsFactory.add(msg);
+            alertsFactory.success(msg);
             $location.path('/main/program_products');
           });
 
       } else {
-        alertsFactory.add({
-          type: 'danger',
-          message: 'Can\'t save a blank form'
-        });
+        alertsFactory.danger('Can\'t save a blank form');
       }
     };
     storageService.get(storageService.PROGRAM_PRODUCTS).then(function(

--- a/app/scripts/controllers/stockcount.js
+++ b/app/scripts/controllers/stockcount.js
@@ -291,7 +291,7 @@ angular.module('lmisChromeApp')
     $scope.changeState = function(direction){
       $scope.currentEntry = $scope.stockCount.unopened[$scope.facilityProductsKeys[$scope.step]];
       if(stockCountFactory.validate.invalid($scope.currentEntry) && direction !== 0){
-        alertsFactory.add({message: $scope.alertMsg, type: 'danger'});
+        alertsFactory.danger($scope.alertMsg);
       }
       else{
         $scope.step = direction === 0? $scope.step-1 : $scope.step + 1;
@@ -308,7 +308,7 @@ angular.module('lmisChromeApp')
         .then(function(uuid){
           var msg = 'You have completed stock count for '+$scope.stockCount.day+
               ' '+$scope.monthList[$scope.reportMonth]+' '+$scope.reportYear;
-          alertsFactory.add({message: msg, type: 'success'});
+          alertsFactory.success(msg);
           $state.go('home.index.mainActivity',
             {
               'facility': $scope.facilityUuid,

--- a/app/scripts/services/alertsfactory.js
+++ b/app/scripts/services/alertsfactory.js
@@ -28,15 +28,24 @@ angular.module('lmisChromeApp')
     };
 
     var info = function(message) {
-      return message;
+      add({
+        type: 'info',
+        message: message
+      });
     };
 
     var warning = function(message) {
-      return message;
+      add({
+        type: 'warning',
+        message: message
+      });
     };
 
     var danger = function(message) {
-      return message;
+      add({
+        type: 'danger',
+        message: message
+      });
     };
 
     var remove = function(index) {

--- a/app/scripts/services/alertsfactory.js
+++ b/app/scripts/services/alertsfactory.js
@@ -4,6 +4,12 @@ angular.module('lmisChromeApp')
   .factory('alertsFactory', function($rootScope, $timeout) {
     $rootScope.alerts = [];
 
+    // Examples
+    //
+    //    alert({type: '[type]', message: 'message'})
+    //
+    // ... where type is a Bootstrap alert class, see:
+    // http://getbootstrap.com/components/#alerts-examples
     var add = function(alert) {
       $rootScope.alerts.push(alert);
       $timeout(function() {
@@ -15,7 +21,10 @@ angular.module('lmisChromeApp')
     };
 
     var success = function(message) {
-      return message;
+      add({
+        type: 'success',
+        message: message
+      });
     };
 
     var info = function(message) {

--- a/app/scripts/services/alertsfactory.js
+++ b/app/scripts/services/alertsfactory.js
@@ -14,6 +14,22 @@ angular.module('lmisChromeApp')
       }, 5000);
     };
 
+    var success = function(message) {
+      return message;
+    };
+
+    var info = function(message) {
+      return message;
+    };
+
+    var warning = function(message) {
+      return message;
+    };
+
+    var danger = function(message) {
+      return message;
+    };
+
     var remove = function(index) {
       $rootScope.alerts.splice(index, 1);
     };
@@ -29,6 +45,10 @@ angular.module('lmisChromeApp')
 
     return {
       add: add,
+      success: success,
+      info: info,
+      warning: warning,
+      danger: danger,
       remove: remove,
       clear: clear
     };

--- a/app/scripts/services/alertsfactory.js
+++ b/app/scripts/services/alertsfactory.js
@@ -62,7 +62,6 @@ angular.module('lmisChromeApp')
     });
 
     return {
-      add: add,
       success: success,
       info: info,
       warning: warning,

--- a/test/spec/services/alertsfactory.js
+++ b/test/spec/services/alertsfactory.js
@@ -123,4 +123,11 @@ describe('Service: alertsFactory', function() {
     });
   });
 
+  it('should expose alert levels', function() {
+    var levels = ['success', 'info', 'warning', 'danger'];
+    levels.forEach(function(level) {
+      expect(alertsFactory[level]).toBeDefined();
+    });
+  });
+
 });

--- a/test/spec/services/alertsfactory.js
+++ b/test/spec/services/alertsfactory.js
@@ -41,12 +41,8 @@ describe('Service: alertsFactory', function() {
     expect(scope.alerts.length).toEqual(0);
   });
 
-  it('should provide an add method', function() {
-    expect(alertsFactory.add).toBeDefined();
-  });
-
   it('should add an alert to the root scope', function() {
-    alertsFactory.add({message: 'Test'});
+    alertsFactory.info('Test');
     expect(scope.alerts.length).toEqual(1);
   });
 
@@ -56,7 +52,7 @@ describe('Service: alertsFactory', function() {
 
   it('should remove an alert by its index', function() {
     expect(scope.alerts.length).toEqual(0);
-    alertsFactory.add({message: 'Test'});
+    alertsFactory.info('Test');
     alertsFactory.remove(0);
     expect(scope.alerts.length).toEqual(0);
   });
@@ -64,7 +60,7 @@ describe('Service: alertsFactory', function() {
   it('should not clobber other alerts when removing', function() {
     var nucleobases = ['Guanine', 'Adenine', 'Thymine', 'Cytosine'];
     nucleobases.forEach(function(nucleobase) {
-      alertsFactory.add({message: nucleobase});
+      alertsFactory.info(nucleobase);
     });
     expect(scope.alerts.length).toEqual(4);
     alertsFactory.remove(2);
@@ -80,7 +76,7 @@ describe('Service: alertsFactory', function() {
   it('should clear alerts when asked', function() {
     var nucleobases = ['Guanine', 'Adenine', 'Thymine', 'Cytosine'];
     nucleobases.forEach(function(nucleobase) {
-      alertsFactory.add({message: nucleobase});
+      alertsFactory.info(nucleobase);
     });
     expect(scope.alerts.length).toEqual(4);
     alertsFactory.clear();
@@ -101,7 +97,7 @@ describe('Service: alertsFactory', function() {
 
       scope.$apply(function() {
         $state.go(ma);
-        alertsFactory.add({message: 'Test'});
+        alertsFactory.info('Test');
         expect(scope.alerts.length).toEqual(1);
       });
 
@@ -116,7 +112,7 @@ describe('Service: alertsFactory', function() {
     inject(function($timeout, $templateCache, $httpBackend) {
       loadMockedTemplates($templateCache);
       loadMockedLocales($httpBackend);
-      alertsFactory.add();
+      alertsFactory.info('');
       expect(scope.alerts.length).toEqual(1);
       $timeout.flush();
       expect(scope.alerts.length).toEqual(0);

--- a/test/spec/services/alertsfactory.js
+++ b/test/spec/services/alertsfactory.js
@@ -140,6 +140,36 @@ describe('Service: alertsFactory', function() {
       alertsFactory.success(expected.message);
       expect(scope.alerts[0]).toEqual(expected);
     });
+
+    it('should set an alert type to info if asked to', function() {
+      var expected = {
+        type: 'info',
+        message: 'Info message'
+      };
+
+      alertsFactory.info(expected.message);
+      expect(scope.alerts[0]).toEqual(expected);
+    });
+
+    it('should set an alert type to warning if asked to', function() {
+      var expected = {
+        type: 'warning',
+        message: 'Warning message'
+      };
+
+      alertsFactory.warning(expected.message);
+      expect(scope.alerts[0]).toEqual(expected);
+    });
+
+    it('should set an alert type to danger if asked to', function() {
+      var expected = {
+        type: 'danger',
+        message: 'Danger message'
+      };
+
+      alertsFactory.danger(expected.message);
+      expect(scope.alerts[0]).toEqual(expected);
+    });
   });
 
 });

--- a/test/spec/services/alertsfactory.js
+++ b/test/spec/services/alertsfactory.js
@@ -123,10 +123,22 @@ describe('Service: alertsFactory', function() {
     });
   });
 
-  it('should expose alert levels', function() {
-    var levels = ['success', 'info', 'warning', 'danger'];
-    levels.forEach(function(level) {
-      expect(alertsFactory[level]).toBeDefined();
+  describe('levels', function() {
+    it('should expose alert levels', function() {
+      var levels = ['success', 'info', 'warning', 'danger'];
+      levels.forEach(function(level) {
+        expect(alertsFactory[level]).toBeDefined();
+      });
+    });
+
+    it('should set an alert type to success if asked to', function() {
+      var expected = {
+        type: 'success',
+        message: 'Success message'
+      };
+
+      alertsFactory.success(expected.message);
+      expect(scope.alerts[0]).toEqual(expected);
     });
   });
 


### PR DESCRIPTION
**API change**: instead of

``` js
alertsFactory.addAlert({type: 'success', message: 'message'});
```

… use:

``` js
alertsFactory.success('message');
```

Closes item:292.
