### PR TITLE
Adds remote stock count synch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ app/bower_components
 npm-debug.log
 test/bower_components
 coverage
+app/scripts/config.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,8 @@ module.exports = function(grunt) {
         tasks: ['newer:copy:styles', 'autoprefixer']
       },
       gruntfile: {
-        files: ['Gruntfile.js']
+        files: ['Gruntfile.js'],
+        tasks: ['ngconstant:development']
       },
       livereload: {
         options: {
@@ -304,6 +305,24 @@ module.exports = function(grunt) {
         // jshint camelcase: false
         coverage_dir: 'coverage'
       }
+    },
+
+    ngconstant: {
+      options: {
+        name: 'config',
+        dest: '<%= yeoman.app %>/scripts/config.js',
+      },
+      // Targets
+      development: {
+        constants: {
+          config: grunt.file.readJSON('config/development.json')
+        }
+      },
+      production: {
+        constants: {
+          config: grunt.file.readJSON('config/production.json')
+        }
+      }
     }
   });
 
@@ -315,6 +334,7 @@ module.exports = function(grunt) {
     grunt.task.run([
       'clean:server',
       'bowerInstall',
+      'ngconstant:development',
       'concurrent:server',
       'autoprefixer',
       'connect:livereload',
@@ -342,6 +362,7 @@ module.exports = function(grunt) {
   grunt.registerTask('build', [
     'clean:dist',
     'bowerInstall',
+    'ngconstant:production',
     'useminPrepare',
     'concurrent:dist',
     'autoprefixer',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -141,7 +141,8 @@ module.exports = function(grunt) {
         exclude: [
           'bower_components/moment/moment.js',
           'ng-table',
-          'angularjs-nvd3-directives'
+          'angularjs-nvd3-directives',
+          'bower_components/pouchdb/index.js'
         ]
       }
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -139,7 +139,9 @@ module.exports = function(grunt) {
         src: '<%= yeoman.app %>/index.html',
         ignorePath: '<%= yeoman.app %>/',
         exclude: [
-          'bower_components/moment/moment.js'
+          'bower_components/moment/moment.js',
+          'ng-table',
+          'angularjs-nvd3-directives'
         ]
       }
     },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -313,6 +313,11 @@ module.exports = function(grunt) {
         dest: '<%= yeoman.app %>/scripts/config.js',
       },
       // Targets
+      test: {
+        constants: {
+          config: grunt.file.readJSON('config/test.json')
+        }
+      },
       development: {
         constants: {
           config: grunt.file.readJSON('config/development.json')
@@ -343,6 +348,7 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('test', function(target) {
+    grunt.task.run(['ngconstant:test']);
     if (target === 'unit') {
       return grunt.task.run(['karma:unit']);
     }

--- a/app/index.html
+++ b/app/index.html
@@ -9,7 +9,6 @@
   <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
   <!-- build:css styles/vendor.css -->
   <!-- bower:css -->
-  <!-- <link rel="stylesheet" href="bower_components/ng-table/ng-table.css" /> -->
   <link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.css" />
   <link rel="stylesheet" href="bower_components/bootstrap-css-only/css/bootstrap.css" />
   <!-- endbower -->
@@ -46,18 +45,16 @@
 <script src="bower_components/angular-resource/angular-resource.js"></script>
 <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
 <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
-<!--FIXME: uncomment <script src="bower_components/ng-table/ng-table.js"></script> -->
 <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
 <script src="bower_components/tv-breadcrumbs/dist/tv-breadcrumbs.min.js"></script>
 <script src="bower_components/angular-translate/angular-translate.js"></script>
 <script src="bower_components/angular-translate-loader-static-files/angular-translate-loader-static-files.js"></script>
 <script src="bower_components/angular-translate-storage-cookie/angular-translate-storage-cookie.js"></script>
 <script src="bower_components/angular-toggle-switch/angular-toggle-switch.min.js"></script>
-<!--FIXME: uncomment
 <script src="bower_components/d3/d3.js"></script>
 <script src="bower_components/nvd3/nv.d3.js"></script>
- uncomment <script src="bower_components/angularjs-nvd3-directives/dist/angularjs-nvd3-directives.js"></script>
- -->
+<script src="bower_components/pouchdb/dist/pouchdb-nightly.js"></script>
+<script src="bower_components/angular-pouchdb/angular-pouchdb.js"></script>
 <!-- endbower -->
 <!-- endbuild -->
 

--- a/app/index.html
+++ b/app/index.html
@@ -53,13 +53,14 @@
 <script src="bower_components/angular-toggle-switch/angular-toggle-switch.min.js"></script>
 <script src="bower_components/d3/d3.js"></script>
 <script src="bower_components/nvd3/nv.d3.js"></script>
-<script src="bower_components/pouchdb-nightly/index.js"></script>
 <script src="bower_components/angular-pouchdb/angular-pouchdb.js"></script>
+<script src="bower_components/pouchdb-nightly/index.js"></script>
 <!-- endbower -->
 <!-- endbuild -->
 
 <!-- build:js({.tmp,app}) scripts/scripts.js -->
 <script src="scripts/app.js"></script>
+<script src="scripts/config.js"></script>
 <script src="scripts/controllers/home.js"></script>
 <script src="scripts/controllers/footer.js"></script>
 

--- a/app/index.html
+++ b/app/index.html
@@ -53,7 +53,7 @@
 <script src="bower_components/angular-toggle-switch/angular-toggle-switch.min.js"></script>
 <script src="bower_components/d3/d3.js"></script>
 <script src="bower_components/nvd3/nv.d3.js"></script>
-<script src="bower_components/pouchdb/index.js"></script>
+<script src="bower_components/pouchdb-nightly/index.js"></script>
 <script src="bower_components/angular-pouchdb/angular-pouchdb.js"></script>
 <!-- endbower -->
 <!-- endbuild -->

--- a/app/index.html
+++ b/app/index.html
@@ -53,7 +53,7 @@
 <script src="bower_components/angular-toggle-switch/angular-toggle-switch.min.js"></script>
 <script src="bower_components/d3/d3.js"></script>
 <script src="bower_components/nvd3/nv.d3.js"></script>
-<script src="bower_components/pouchdb/dist/pouchdb-nightly.js"></script>
+<script src="bower_components/pouchdb/index.js"></script>
 <script src="bower_components/angular-pouchdb/angular-pouchdb.js"></script>
 <!-- endbower -->
 <!-- endbuild -->

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -106,5 +106,10 @@
   "discrepancyThreshold": "Discrepancy Threshold",
   "counterSample": "Counter Sample",
   "stockCountSaved": "Stock count saved. Syncronising with cloud backup…",
-  "syncSuccess": "Successfully syncronised"
+  "syncSuccess": "Successfully syncronised",
+  "syncStockCount": "Sync stock count",
+  "sync": "Sync",
+  "local": "Local",
+  "remote": "Remote",
+  "records": "Records"
 }

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -104,5 +104,7 @@
   "bufferStock": "Buffer Stock",
   "reorderPoint": "Reorder Point",
   "discrepancyThreshold": "Discrepancy Threshold",
-  "counterSample": "Counter Sample"
+  "counterSample": "Counter Sample",
+  "stockCountSaved": "Stock count saved. Syncronising with cloud backup…",
+  "syncSuccess": "Successfully syncronised"
 }

--- a/app/locales/en_GB.json
+++ b/app/locales/en_GB.json
@@ -1,5 +1,7 @@
 {
   "authorize": "Authorise",
   "supplementalImmunizationActivity": "Supplemental Immunisation Activity",
-  "routineImmunization": "Routine Immunisation"
+  "routineImmunization": "Routine Immunisation",
+  "stockCountSaved": "Stock count saved. Synchronising with cloud backup…",
+  "syncSuccess": "Successfully synchronised"
 }

--- a/app/locales/en_GB.json
+++ b/app/locales/en_GB.json
@@ -3,5 +3,7 @@
   "supplementalImmunizationActivity": "Supplemental Immunisation Activity",
   "routineImmunization": "Routine Immunisation",
   "stockCountSaved": "Stock count saved. Synchronising with cloud backup…",
-  "syncSuccess": "Successfully synchronised"
+  "syncSuccess": "Successfully synchronised",
+  "syncStockCount": "Synch stock count",
+  "sync": "Synch"
 }

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -9,7 +9,8 @@ angular.module('lmisChromeApp', [
       'ui.router',
       'tv.breadcrumbs',
       'pascalprecht.translate',
-      'toggle-switch'
+      'toggle-switch',
+      'pouchdb'
       //FIXME: uncomment 'nvd3ChartDirectives'
     ])
   // Disable ui-router auto scrolling

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -10,7 +10,8 @@ angular.module('lmisChromeApp', [
       'tv.breadcrumbs',
       'pascalprecht.translate',
       'toggle-switch',
-      'pouchdb'
+      'pouchdb',
+      'config'
       //FIXME: uncomment 'nvd3ChartDirectives'
     ])
   // Disable ui-router auto scrolling

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -127,3 +127,6 @@ accordion .panel-heading:hover {
 .btn-separator{
     margin-top: 2.5em;
 }
+.fa-5-3x {
+  font-size: 5.3em;
+}

--- a/app/views/home/main-activity.html
+++ b/app/views/home/main-activity.html
@@ -16,6 +16,13 @@
         <span translate="counterSample"></span>
       </a>
 
+      <a ui-sref="syncStockCount" class="btn btn-default">
+        <span>
+          <i class="fa fa-cloud fa-5-3x"></i>
+        </span>
+        <span translate="syncStockCount"></span>
+      </a>
+
       <!--<a ui-sref="home.index.mainActivity.orderType" class="btn btn-default">
         <img src="images/dashboard-icons/place_order.png" class="img-rounded">
         <span translate="incomingPlace"></span>

--- a/app/views/stockcount/sync.html
+++ b/app/views/stockcount/sync.html
@@ -1,0 +1,39 @@
+<div class="row">
+  <div class="col-sm-3">
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title" translate="stockCount"></h3>
+      </div>
+      <div class="panel-body">
+        <span translate="records"></span>
+        <dl class="dl-horizontal">
+          <dt translate="local"></dt>
+          <dd ng-bind="local.doc_count"></dd>
+          <dt translate="remote"></dt>
+          <dd>
+            <span
+              ng-show="!remoteSyncing"
+              ng-bind="remote.doc_count">
+            </span>
+            <span ng-show="remoteSyncing">
+              <i class="fa fa-spinner fa-spin"></i>
+            </span>
+          </dd>
+        </dl>
+
+        <button
+          class="btn btn-default pull-right"
+          ng-click="sync()">
+          <i
+            class="fa fa-refresh"
+            ng-class="{'fa-spin': syncing}">
+          </i>
+          <span translate="sync"></span>
+        </button>
+
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,8 @@
     "d3": "~3.4.3",
     "nvd3": "~1.1.15-beta",
     "angularjs-nvd3-directives": "~0.0.5-beta",
-    "angular-pouchdb": "tlvince/angular-pouchdb"
+    "angular-pouchdb": "tlvince/angular-pouchdb",
+    "pouchdb-nightly": "https://gist.githubusercontent.com/tlvince/9769464/raw/c83878e990ad8e85e8f6597edf4070e233176707/pouchdb-nightly.js"
   },
   "devDependencies": {
     "angular-mocks": "1.2.14"

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,8 @@
     "angular-toggle-switch": "~0.3.0",
     "d3": "~3.4.3",
     "nvd3": "~1.1.15-beta",
-    "angularjs-nvd3-directives": "~0.0.5-beta"
+    "angularjs-nvd3-directives": "~0.0.5-beta",
+    "angular-pouchdb": "tlvince/angular-pouchdb"
   },
   "devDependencies": {
     "angular-mocks": "1.2.14"
@@ -40,6 +41,7 @@
   "resolutions": {
     "angular": "1.2.14",
     "nvd3": "v1.1.14-beta",
-    "d3": "3.3.11"
+    "d3": "3.3.11",
+    "angular-pouchdb": "d920e0c060"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,6 @@
   "resolutions": {
     "angular": "1.2.14",
     "nvd3": "v1.1.14-beta",
-    "d3": "3.3.11",
-    "angular-pouchdb": "d920e0c060"
+    "d3": "3.3.11"
   }
 }

--- a/config/development.json
+++ b/config/development.json
@@ -1,0 +1,3 @@
+{
+  "apiBaseURI": "https://ehealth.iriscouch.com"
+}

--- a/config/production.json
+++ b/config/production.json
@@ -1,0 +1,3 @@
+{
+  "apiBaseURI": "https://ehealth.iriscouch.com"
+}

--- a/config/test.json
+++ b/config/test.json
@@ -1,0 +1,3 @@
+{
+  "apiBaseURI": "https://ehealth.iriscouch.com"
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -30,6 +30,7 @@ module.exports = function(config) {
       'app/bower_components/nvd3/nv.d3.js',
       'app/bower_components/moment/moment.js',
       'app/bower_components/angularjs-nvd3-directives/dist/angularjs-nvd3-directives.js',
+      'app/bower_components/angular-pouchdb/angular-pouchdb.js',
       'app/scripts/**/*.js',
       'test/mock/**/*.js',
       'test/spec/**/*.js'

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "grunt-karma-coveralls": "^2.4.3",
     "karma-coverage": "^0.2.0",
     "semver": "^2.2.1",
-    "gift": "^0.3.0"
+    "gift": "^0.3.0",
+    "grunt-ng-constant": "^0.5.0"
   },
   "engines": {
     "node": "0.10.x"


### PR DESCRIPTION
- Implemented using a Chrome-compatible PouchDB build
- New stock counts are "backed up to the cloud"
- Adds a dashboard button to manually initiate a synch
- Use grunt-ng-constant to manage per-environment config
