### PR TITLE
add get() method options parameter

### DIFF
--- a/app/scripts/services/chrome-storage-api.js
+++ b/app/scripts/services/chrome-storage-api.js
@@ -28,17 +28,21 @@ angular.module('lmisChromeApp').factory('chromeStorageApi', function ($window, $
     },
     /*
      * Get method should work for both cases returning particular item or entire collection.
-     * @param {boolean} mode - whether return data of particular item (false) or entire collection (true).
+     * @param {Object} options - if undefined, default value is return data of a particular item
+     * or entire collection (if set to {collection:true})
      */
-    get: function (item, mode) {
+    get: function (item, options) {
       var deferred = $q.defer();
       if(chromeStorage){
         chromeStorage.get(item, function(data){
           if($window.chrome.runtime.lastError !== undefined) {
             deferred.reject($window.chrome.runtime.lastError);
           }
-          if(mode){ deferred.resolve(data);
-          } else { deferred.resolve(data[item]); }
+          if(options && options.collection) {
+              deferred.resolve(data);
+          } else {
+              deferred.resolve(data[item]);
+          }
         });
       } else {
         deferred.reject("chrome.storage api is not available");

--- a/app/scripts/services/storage-service.js
+++ b/app/scripts/services/storage-service.js
@@ -93,7 +93,7 @@ angular.module('lmisChromeApp')
        */
 
       function getData(key) {
-         var promise = chromeStorageApi.get(key, false);
+         var promise = chromeStorageApi.get(key);
          return promise;
         }
 
@@ -105,7 +105,7 @@ angular.module('lmisChromeApp')
        */
         // TODO - consider to deprecate
         function getAllFromStore() {
-          var promise = chromeStorageApi.get(null, true);
+          var promise = chromeStorageApi.get(null, {collection:true});
           return promise;
         }
 

--- a/test/spec/services/chrome-storage-api.js
+++ b/test/spec/services/chrome-storage-api.js
@@ -21,13 +21,14 @@ describe('chromeStorageApi', function () {
     });
 
     it('should be able to get an item from the storage', function() {
-        chromeStorageApi.get('a', false);
-        expect($window.chrome.storage.local.get('a', false)).toEqual('b');
+        chromeStorageApi.get('a');
+        expect($window.chrome.storage.local.get('a')).toEqual('b');
     });
 
     it('should be able to get entire collection from the storage', function() {
-        chromeStorageApi.get(null, true);
-        expect($window.chrome.storage.local.get(null, true)).toEqual({a:'b', c:'d'});
+        var options = {collection:true};
+        chromeStorageApi.get(null, options);
+        expect($window.chrome.storage.local.get(null, options)).toEqual({a:'b', c:'d'});
     });
 
     it('should be able to remove an item from the storage', function() {


### PR DESCRIPTION
I have refactored get() method to use 'options' object as a optional parameter to defined whether return an item or entire collection according to item:#360.
