### PR TITLE
Strip logging in production, closes #525

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -220,6 +220,19 @@ module.exports = function(grunt) {
       }
     },
 
+    removelogging: {
+      dist: {
+        src: '.tmp/concat/scripts/scripts.js',
+        options: {
+          namespace: [
+            'console',
+            'window.console',
+            '\\$log'
+          ]
+        }
+      }
+    },
+
     // Allow the use of non-minsafe AngularJS files. Automatically makes it
     // minsafe compatible so Uglify does not destroy the ng references
     ngAnnotate: {
@@ -410,23 +423,39 @@ module.exports = function(grunt) {
     ]);
   });
 
-  grunt.registerTask('build', [
-    'clean:dist',
-    'wiredep',
-    'ngconstant:production',
-    'chromeManifest:dist',
-    'useminPrepare',
-    'concurrent:dist',
-    'autoprefixer',
-    'concat',
-    'ngAnnotate',
-    'copy:dist',
-    'cssmin',
-    'uglify',
-    'rev',
-    'usemin',
-    'htmlmin'
-  ]);
+  grunt.registerTask('build', function(target) {
+    var head = [
+      'clean:dist',
+      'wiredep',
+      'ngconstant:production',
+      'chromeManifest:dist',
+      'useminPrepare',
+      'concurrent:dist',
+      'autoprefixer',
+      'concat'
+    ];
+
+    var torso = [
+      'removelogging'
+    ];
+
+    var tail = [
+      'ngAnnotate',
+      'copy:dist',
+      'cssmin',
+      'uglify',
+      'rev',
+      'usemin',
+      'htmlmin'
+    ];
+
+    if(target === 'release') {
+      grunt.task.run(head.concat(torso, tail));
+    }
+    else {
+      grunt.task.run(head.concat(tail));
+    }
+  });
 
   grunt.registerTask('default', [
     'newer:jshint',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "lmis-chrome",
   "version": "0.9.0",
   "private": true,
-  "dependencies": {},
+  "dependencies": {
+    "grunt-remove-logging": "^0.2.0"
+  },
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-autoprefixer": "~0.7.2",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,7 +10,7 @@ info() { echo "$0: $1"; }
 error() { info "$1"; exit 1;}
 
 info "Running grunt build"
-grunt build
+[[ "$TRAVIS_TAG" ]] && grunt build:release || grunt build
 
 info "Building Mobile Chrome App"
 have "cca" || npm install -g cca


### PR DESCRIPTION
Only triggered on release builds (`grunt build:release`).
