### PR TITLE
wiredep-managed font-awesome, closes item:570

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -5,8 +5,8 @@
   <title>Nigeria LMIS</title>
   <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height">
   <!-- build:css styles/vendor.css -->
-  <link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.css" />
   <!-- bower:css -->
+  <link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.css" />
   <link rel="stylesheet" href="bower_components/bootstrap-css-only/css/bootstrap.css" />
   <link rel="stylesheet" href="bower_components/bootstrap-theme-cosmo/cosmo.min.css" />
   <link rel="stylesheet" href="bower_components/nvd3/src/nv.d3.css" />


### PR DESCRIPTION
Seems like Font Awesome 4.1.0 has fixed the issue already:

``` bash
bower info font-awesome\#4.1.0 main
```

This just moves FA into the `bower` block.
