### PR TITLE
Drop fastclick, refs item:557

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -27,7 +27,6 @@
   <script src="bower_components/tv-breadcrumbs/dist/tv-breadcrumbs.min.js"></script>
   <script src="bower_components/pouchdb/dist/pouchdb-nightly.js"></script>
   <script src="bower_components/angular-pouchdb/angular-pouchdb.js"></script>
-  <script src="bower_components/fastclick/lib/fastclick.js"></script>
   <script src="bower_components/d3/d3.js"></script>
   <script src="bower_components/nvd3/nv.d3.js"></script>
   <script src="bower_components/angularjs-nvd3-directives/dist/angularjs-nvd3-directives.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -24,10 +24,6 @@ angular.module('lmisChromeApp', [
     $rootScope.$on('LOADING_COMPLETED', $window.hideSplashScreen);
     $rootScope.$on('START_LOADING', $window.showSplashScreen);
 
-    if(typeof FastClick !== 'undefined'){
-      FastClick.attach(document.body);
-    }
-
     //load fixtures if not loaded yet.
     storageService.loadFixtures().then(function(){
       //update appConfig from remote then trigger background syncing

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,6 @@
     "tv-breadcrumbs": "~0.1.1",
     "bootstrap-css-only": "~3.1.0",
     "angular-pouchdb": "tlvince/angular-pouchdb#0.1.1",
-    "fastclick": "~1.0.0",
     "bootstrap-theme-cosmo": "tlvince/bootstrap-theme-cosmo#4c161a6bf5bebe0ecfbef0771e053c8c5c2698c9",
     "angularjs-nvd3-directives": "~0.0.7",
     "queue-async": "~1.0.7",


### PR DESCRIPTION
According to [fastclick#when-it-isnt-needed](https://github.com/ftlabs/fastclick#when-it-isnt-needed), if `width=device-width` or
`user-scalable=no` is set in the viewport meta tag, Chrome for Android will not
have a 300ms tap delay (FastClick checks for these tags and doesn't attach if
present).

We have both of those attributes set and are only targeting Android.
