### PR TITLE
Add static code analysis tools, refs item:557

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,9 +28,7 @@ rules:
     - declaration
   no-nested-ternary: 2
   no-lonely-if: 2
-  space-after-keywords:
-    - 2
-    - never
+  space-after-keywords: 2
   space-in-brackets: 2
   block-scoped-var: 2
   default-case: 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -19,3 +19,21 @@ rules:
   no-undef: 2
   no-unused-vars: 2
   strict: 2
+  no-extra-parens: 2
+  brace-style:
+    - 2
+    - 1tbs
+  func-style:
+    - 2
+    - declaration
+  no-nested-ternary: 2
+  no-lonely-if: 2
+  space-after-keywords:
+    - 2
+    - never
+  space-in-brackets: 2
+  block-scoped-var: 2
+  default-case: 2
+  no-else-return: 2
+  no-eq-null: 2
+  no-floating-decimal: 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,21 @@
+env:
+  node: true
+  browser: true
+globals:
+  angular: false
+  chrome: false
+rules:
+  quotes:
+    - 2
+    - single
+  camelcase: 2
+  curly:
+    - 2
+    - all
+  eqeqeq: 2
+  wrap-iife: 2
+  no-use-before-define: 2
+  new-cap: 2
+  no-undef: 2
+  no-unused-vars: 2
+  strict: 2

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,7 @@
 {
   "preset": "google",
   "requireParenthesesAroundIIFE": true,
+  "maximumLineLength": 80,
+  "validateIndentation": 2,
   "validateLineBreaks": "LF"
 }

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,5 @@
+{
+  "preset": "google",
+  "requireParenthesesAroundIIFE": true,
+  "validateLineBreaks": "LF"
+}

--- a/.ngconstant.tpl.ejs
+++ b/.ngconstant.tpl.ejs
@@ -1,0 +1,8 @@
+'use strict';
+
+angular.module('{%- moduleName %}'{% if (deps) { %}, {%= JSON.stringify(deps) %}{% } %})
+{% constants.forEach(function (constant) { %}
+.constant('{%- constant.name %}', {%= constant.value %})
+{% }); values.forEach(function (value) { %}
+.value('{%- value.name %}', {%= value.value %})
+{% }) %};

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -430,6 +430,14 @@ module.exports = function(grunt) {
         },
         src: '<%= jshint.test.src %>'
       }
+    },
+
+    jsbeautifier: {
+      options: {
+        mode: 'VERIFY_ONLY',
+        jsbeautifyrc: true
+      },
+      src: '<%= jshint.all %>'
     }
   });
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -438,6 +438,10 @@ module.exports = function(grunt) {
         jsbeautifyrc: true
       },
       src: '<%= jshint.all %>'
+    },
+
+    jscs: {
+      src: '<%= jshint.all %>'
     }
   });
 
@@ -536,6 +540,7 @@ module.exports = function(grunt) {
   grunt.registerTask('checkstyle', [
     'jshint',
     'eslint',
+    'jscs',
     'jsbeautifier'
   ]);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -102,7 +102,7 @@ module.exports = function(grunt) {
         options: {
           jshintrc: 'test/.jshintrc'
         },
-        src: ['test/spec/{,*/}*.js']
+        src: ['test/{,*/}*.js']
       }
     },
 
@@ -174,7 +174,7 @@ module.exports = function(grunt) {
     usemin: {
       html: [
         '<%= yeoman.dist %>/*.html',
-        '<%= yeoman.dist %>/views/**/*.html',
+        '<%= yeoman.dist %>/views/**/*.html'
       ],
       css: ['<%= yeoman.dist %>/styles/{,*/}*.css'],
       options: {
@@ -337,6 +337,7 @@ module.exports = function(grunt) {
       options: {
         force: true,
         // jshint camelcase: false
+        /*eslint camelcase: 0 */
         coverage_dir: 'coverage'
       }
     },
@@ -416,6 +417,19 @@ module.exports = function(grunt) {
           wiredep: '<%= wiredep.target %>'
         }
       }
+    },
+
+    eslint: {
+      options: {
+        config: '.eslintrc'
+      },
+      all: [
+        'Gruntfile.js',
+        '<%= yeoman.app %>/scripts/{,*/}*.js'
+      ],
+      test: {
+        src: ['test/{,*/}*.js']
+      }
     }
   });
 
@@ -482,10 +496,9 @@ module.exports = function(grunt) {
       'wiredepCopy:snapshot'
     ];
 
-    if(target === 'release') {
+    if (target === 'release') {
       grunt.task.run(common.concat(release));
-    }
-    else {
+    } else {
       grunt.task.run(common.concat(snapshot));
     }
   });
@@ -503,7 +516,7 @@ module.exports = function(grunt) {
 
   grunt.registerTask('release', function(versionType) {
     var bump = 'bump';
-    if(versionType) {
+    if (versionType) {
       bump += ':' + versionType;
     }
     grunt.task.run([

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
         }
       },
       jsTest: {
-        files: ['test/spec/{,*/}*.js'],
+        files: ['test/**/*.js'],
         tasks: ['newer:jshint:test', 'karma']
       },
       styles: {
@@ -96,13 +96,13 @@ module.exports = function(grunt) {
       },
       all: [
         'Gruntfile.js',
-        '<%= yeoman.app %>/scripts/{,*/}*.js'
+        '<%= yeoman.app %>/scripts/**/*.js'
       ],
       test: {
         options: {
           jshintrc: 'test/.jshintrc'
         },
-        src: ['test/{,*/}*.js']
+        src: ['test/**/*.js']
       }
     },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -345,6 +345,10 @@ module.exports = function(grunt) {
       options: {
         name: 'config',
         dest: '<%= yeoman.app %>/scripts/config.js',
+        template: grunt.file.read('.ngconstant.tpl.ejs'),
+        serializer: function(obj) {
+          return require('util').inspect(obj);
+        }
       },
       // Targets
       test: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -532,4 +532,10 @@ module.exports = function(grunt) {
       bump
     ]);
   });
+
+  grunt.registerTask('checkstyle', [
+    'jshint',
+    'eslint',
+    'jsbeautifier'
+  ]);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -423,12 +423,12 @@ module.exports = function(grunt) {
       options: {
         config: '.eslintrc'
       },
-      all: [
-        'Gruntfile.js',
-        '<%= yeoman.app %>/scripts/{,*/}*.js'
-      ],
+      all: '<%= jshint.all %>',
       test: {
-        src: ['test/{,*/}*.js']
+        options: {
+          config: 'test/.eslintrc'
+        },
+        src: '<%= jshint.test.src %>'
       }
     }
   });

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -13,11 +13,11 @@ angular.module('lmisChromeApp', [
   // Load fixture data
   .run(function(storageService, $rootScope, $state, $window, appConfigService) {
 
-    $window.showSplashScreen = function(){
+    $window.showSplashScreen = function() {
       $state.go('loadingFixture');
     };
 
-    $window.hideSplashScreen = function(){
+    $window.hideSplashScreen = function() {
       $state.go('home.index.home.mainActivity');
     };
 
@@ -25,18 +25,17 @@ angular.module('lmisChromeApp', [
     $rootScope.$on('START_LOADING', $window.showSplashScreen);
 
     //load fixtures if not loaded yet.
-    storageService.loadFixtures().then(function(){
+    storageService.loadFixtures().then(function() {
       //update appConfig from remote then trigger background syncing
       appConfigService.getCurrentAppConfig().then(function(cfg) {
-        if(typeof cfg !== 'undefined')
-        {
+        if (typeof cfg !== 'undefined') {
           appConfigService.updateAppConfigAndStartBackgroundSync()
-            .finally(function () {
+            .finally(function() {
               console.log('updateAppConfigAndStartBackgroundSync triggered on start up have been completed!');
             });
         }
       });
-      storageService.getAll().then(function (data) {
+      storageService.getAll().then(function(data) {
         console.log('finished loading: ' + (Object.keys(data)).join('\n'));
       });
     });

--- a/app/scripts/controllers/app-config.js
+++ b/app/scripts/controllers/app-config.js
@@ -95,7 +95,7 @@ angular.module('lmisChromeApp').config(function ($stateProvider) {
 }).controller('AppConfigWizard', function($scope, facilities, appConfigService, growl, $state, alertFactory,
         i18n, deviceEmail, $log, ccuProfilesGroupedByCategory, productProfilesGroupedByCategory, utility){
 
-  $scope.spaceOutUpperCaseWords = utility.spaceOutUpperCaseWords
+  $scope.spaceOutUpperCaseWords = utility.spaceOutUpperCaseWords;
   $scope.isSubmitted = false;
   $scope.preSelectProductProfileCheckBox = {};
   $scope.stockCountIntervals = appConfigService.stockCountIntervals;
@@ -193,7 +193,7 @@ angular.module('lmisChromeApp').config(function ($stateProvider) {
 }).controller('EditAppConfigCtrl', function ($scope, facilities, appConfigService, growl, $log, i18n, $state, appConfig,
                                              ccuProfilesGroupedByCategory, productProfilesGroupedByCategory, utility, alertFactory) {
 
-  $scope.spaceOutUpperCaseWords = utility.spaceOutUpperCaseWords
+  $scope.spaceOutUpperCaseWords = utility.spaceOutUpperCaseWords;
   $scope.stockCountIntervals = appConfigService.stockCountIntervals;
   $scope.weekDays = appConfigService.weekDays;
   $scope.facilities = facilities;

--- a/app/scripts/controllers/batches.js
+++ b/app/scripts/controllers/batches.js
@@ -11,7 +11,7 @@ angular.module('lmisChromeApp')
             templateUrl: '/views/batches/index.html',
             controller: 'BatchListCtrl',
             data: {
-              label: "Batch List"
+              label: 'Batch List'
             },
             resolve: {
               batchList: function (batchFactory) {
@@ -23,9 +23,9 @@ angular.module('lmisChromeApp')
             templateUrl: '/views/batches/add-batch-form.html',
             controller: 'AddBatchCtrl',
             data: {
-              label: "Add Batch"
+              label: 'Add Batch'
             }
-          })
+          });
     })
 /**
  * BatchListCtrl - This handles the display of Batches List View
@@ -60,8 +60,9 @@ angular.module('lmisChromeApp')
               params.page() * params.count()
           ));
         }
-      }
+      };
 
+      // jshint newcap: false
       $scope.batches = new ngTableParams(params, resolver);
     })
 /**
@@ -108,7 +109,7 @@ angular.module('lmisChromeApp')
       });
 
       $scope.onProfileSelection = function () {
-        console.log("new profile selected ==> " + $scope.productItem.profile);
+        console.log('new profile selected ==> ' + $scope.productItem.profile);
       };
 
       /**

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "grunt-contrib-watch": "~0.6.1",
     "grunt-eslint": "^0.5.0",
     "grunt-jsbeautifier": "^0.2.7",
+    "grunt-jscs-checker": "^0.4.4",
     "grunt-karma": "~0.8.2",
     "grunt-karma-coveralls": "^2.4.3",
     "grunt-newer": "~0.7.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "grunt-karma-coveralls": "^2.4.3",
     "grunt-newer": "~0.7.0",
     "grunt-ng-annotate": "^0.2.2",
-    "grunt-ng-constant": "^0.5.0",
+    "grunt-ng-constant": "git+https://github.com/werk85/grunt-ng-constant#b46a32f99039fe2531dd680a1cc626a5f6f95f5f",
     "grunt-protractor-runner": "^1.0.0",
     "grunt-remove-logging": "^0.2.0",
     "grunt-rev": "~0.1.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-eslint": "^0.5.0",
+    "grunt-jsbeautifier": "^0.2.7",
     "grunt-karma": "~0.8.2",
     "grunt-karma-coveralls": "^2.4.3",
     "grunt-newer": "~0.7.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-uglify": "~0.4.0",
     "grunt-contrib-watch": "~0.6.1",
+    "grunt-eslint": "^0.5.0",
     "grunt-karma": "~0.8.2",
     "grunt-karma-coveralls": "^2.4.3",
     "grunt-newer": "~0.7.0",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,17 @@
+globals:
+  after: false
+  afterEach: false
+  angular: false
+  before: false
+  beforeEach: false
+  browser: false
+  describe: false
+  ddescribe: false
+  expect: false
+  inject: false
+  it: false
+  iit: false
+  jasmine: false
+  spyOn: false
+  runs: false
+  waitsFor: false


### PR DESCRIPTION
I came across the article [Eliminating Code Smell With Grunt](https://gist.github.com/gvn/7536832) and particularly liked the [enforcement section](https://gist.github.com/gvn/7536832#enforcement).

This adds a new grunt task `grunt checkstyle`, which runs the codebase through a number of static code analysis tools (JSHint, ESLint, jscs, jsbeautify).

We've started documenting our [coding conventions](https://github.com/eHealthAfrica/LMIS-Chrome/wiki/Coding-Conventions), but rarely is it enforced. As the codebase grows, we need to be wary of code smells (a recent one being overloading of returned values). These tools can help prevent such smells and enforce consistency throughout, particularly helpful for new developers reviewing the code.

JSHint is the current de facto Javascript linting tool, but it's not extensible. I propose the introduction of ESLint and jscs.

ESLint is akin to JSHint, but pluggable: every rule is well-defined, it's easy to add new ones and it covers a lot of useful areas such as [space-after-keywords](http://eslint.org/docs/rules/space-after-keywords.html) that JSHint doesn't. It focusses on linting and will
soon be a JSHint replacement when feature parity is reached.

jscs focusses on code style and therefore has more control over formatting and whitespace rules.

I've added a starting `.eslintrc` and `.jscsrc` based on our existing conventions and [popular conventions](http://sideeffect.kr/popularconvention#javascript) in the OSS community. However, these are very much up for refinement between the team.

To enforce these conventions, it's as simple as adding the `checkstyle` task to Travis, which will fail the build if there are deviations. Developers are also encouraged to use IDE plugins or even a Git pre-commit hook as a first pass locally.

I've left this out for now as the rules need discussion and there's a long way to go before everything is lint-free (try running `grunt checkstyle` to see for yourself).

It's a little draconian, but as the project grows, it's important to maintain consistency, to aid readability and kill smells quickly.
