### PR TITLE
Exclude chromereload in Karma

### DIFF
--- a/app/scripts/chromereload.js
+++ b/app/scripts/chromereload.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Reload client for Chrome Apps & Extensions.
-// The relaod client has a compatibility with livereload.
+// The reload client has a compatibility with livereload.
 // WARNING: only supports reload command.
 
 var connection = new WebSocket('ws://localhost:35729/livereload');
@@ -11,9 +11,9 @@ connection.onerror = function(error) {
 };
 
 connection.onmessage = function(e) {
-  if(e.data) {
+  if (e.data) {
     var data = JSON.parse(e.data);
-    if(data && data.command === 'reload') {
+    if (data && data.command === 'reload') {
       chrome.runtime.reload();
     }
   }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -26,7 +26,8 @@ module.exports = function(config) {
 
     // list of files / patterns to exclude
     exclude: [
-      'app/scripts/main.js'
+      'app/scripts/main.js',
+      'app/scripts/chromereload.js'
     ],
 
     // web server port
@@ -67,7 +68,7 @@ module.exports = function(config) {
       dir: 'coverage'
     },
     ngHtml2JsPreprocessor: {
-      stripPrefix: 'app/',
+      stripPrefix: 'app/'
     },
     plugins: [
       'karma-*'


### PR DESCRIPTION
Occasionally, tests would fail as live reload erroneously was being included in
the test suite(!).
