### PR TITLE
Simplify analytics handling, refs item:283

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -92,10 +92,10 @@
   <script src="scripts/services/alert-factory.js"></script>
   <script src="scripts/services/cache-service.js"></script>
   <script src="scripts/services/ccu-profile-factory.js"></script>
+  <script src="scripts/services/tracking-factory.js"></script>
   <script src="scripts/directives/counter.js"></script>
   <script src="scripts/directives/i18n.js"></script>
-  <script src="scripts/directives/analytics-directive.js"></script>
-  <script src="scripts/services/tracking-factory.js"></script>
+  <script src="scripts/directives/analytics.js"></script>
   <!-- endbuild -->
 </body>
 </html>

--- a/app/scripts/directives/analytics-directive.js
+++ b/app/scripts/directives/analytics-directive.js
@@ -7,7 +7,7 @@ angular.module('lmisChromeApp')
       link: function(scope, element, attr) {
         var tracker = trackingFactory.tracker;
         element.on('click', function() {
-          tracker.sendEvent('Click', element.text(), attr.lmisPageViewReport);
+          tracker.sendEvent('Click', element.text(), attr.lmisAnalyticsDirective);
         });
       }
     };

--- a/app/scripts/directives/analytics-directive.js
+++ b/app/scripts/directives/analytics-directive.js
@@ -5,17 +5,10 @@ angular.module('lmisChromeApp')
     return {
       restrict: 'AE',
       link: function(scope, element, attr) {
-        var tracker = trackingFactory.tracker();
+        var tracker = trackingFactory.tracker;
         element.on('click', function() {
           tracker.sendEvent('Click', element.text(), attr.lmisPageViewReport);
         });
       }
-    };
-  })
-
-  .directive('lmisPageViewReport', function(trackingFactory) {
-    return function(scope, element, attr) {
-      var tracker = trackingFactory.tracker();
-      tracker.sendAppView(attr.lmisPageViewReport);
     };
   });

--- a/app/scripts/directives/analytics-directive.js
+++ b/app/scripts/directives/analytics-directive.js
@@ -3,7 +3,7 @@
 angular.module('lmisChromeApp')
   .directive('lmisAnalyticsDirective', function(trackingFactory) {
     return {
-      restrict: 'AE',
+      restrict: 'A',
       link: function(scope, element, attr) {
         var tracker = trackingFactory.tracker;
         element.on('click', function() {

--- a/app/scripts/directives/analytics.js
+++ b/app/scripts/directives/analytics.js
@@ -1,13 +1,13 @@
 'use strict';
 
 angular.module('lmisChromeApp')
-  .directive('lmisAnalyticsDirective', function(trackingFactory) {
+  .directive('gaClick', function(trackingFactory) {
     return {
       restrict: 'A',
       link: function(scope, element, attr) {
         var tracker = trackingFactory.tracker;
         element.on('click', function() {
-          tracker.sendEvent('Click', element.text(), attr.lmisAnalyticsDirective);
+          tracker.sendEvent('Click', element.text(), attr.gaClick);
         });
       }
     };

--- a/app/scripts/directives/analytics.js
+++ b/app/scripts/directives/analytics.js
@@ -7,7 +7,7 @@ angular.module('lmisChromeApp')
       link: function(scope, element, attr) {
         var tracker = trackingFactory.tracker;
         element.on('click', function() {
-          tracker.sendEvent('Click', element.text(), attr.gaClick);
+          tracker.sendEvent('Click', element.text().trim(), attr.gaClick);
         });
       }
     };

--- a/app/scripts/services/tracking-factory.js
+++ b/app/scripts/services/tracking-factory.js
@@ -1,13 +1,23 @@
 'use strict';
 
 angular.module('lmisChromeApp')
-  .factory('trackingFactory', function($window, config) {
+  .factory('trackingFactory', function($window, $rootScope, config) {
+
+    var tracker;
+    if ('analytics' in $window) {
+      var service = $window.analytics.getService(config.analytics.service);
+      tracker = service.getTracker(config.analytics.propertyID);
+
+      $rootScope.$on('$stateChangeSuccess', function(event, state) {
+        tracker.sendAppView(state.name);
+      });
+
+      $rootScope.$on('$stateNotFound', function(event, state) {
+        tracker.sendException(state.to, false);
+      });
+    }
+
     return {
-      tracker: function() {
-        if ('analytics' in $window) {
-          var service = $window.analytics.getService(config.analytics.service);
-          return service.getTracker(config.analytics.propertyID);
-        }
-      }
+      tracker: tracker
     };
   });

--- a/app/views/app-config/edit-configuration.html
+++ b/app/views/app-config/edit-configuration.html
@@ -35,7 +35,7 @@
       <div class="panel-body"></div>
       <div class="col-sm-12">
         <div class="col-md-4 pull-left">
-          <button type="submit" lmis-analytics-directive="save" id="save" name="save" class="btn btn-success btn-lg" ng-click="isSubmitted = true"
+          <button type="submit" ga-click="save" id="save" name="save" class="btn btn-success btn-lg" ng-click="isSubmitted = true"
                   ng-disabled="isSaving">
             <span ng-show="!isSaving" i18n="save"></span>
             <span ng-show="!isSaving"><i class="fa fa-floppy-o"></i></i></span>

--- a/app/views/app-config/edit-configuration.html
+++ b/app/views/app-config/edit-configuration.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <form lmis-page-view-report="app-config_edit-configuration" name="editAppConfigForm" ng-submit="editAppConfigForm.$valid && save()" novalidate>
+  <form name="editAppConfigForm" ng-submit="editAppConfigForm.$valid && save()" novalidate>
 
     <div class="col-sm-12">
       <div class="panel panel-default">

--- a/app/views/app-config/partials/forms/ccu-profile.html
+++ b/app/views/app-config/partials/forms/ccu-profile.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="app-config_partials_forms_ccu-profile" class="col-md-12">
+<div class="col-md-12">
 
   <div class="panel panel-default">
     <div class="panel-heading">

--- a/app/views/app-config/partials/forms/contact-person.html
+++ b/app/views/app-config/partials/forms/contact-person.html
@@ -1,5 +1,5 @@
 <fieldset>
-  <div lmis-page-view-report="app-config_partials_forms_contact-person" class="row">
+  <div class="row">
     <div class="col-sm-6">
       <div class="form-group" ng-class="{ 'has-error': ((editAppConfigForm.contactPersonName).$error).required
                       && isSubmitted }">

--- a/app/views/app-config/partials/forms/facility-info.html
+++ b/app/views/app-config/partials/forms/facility-info.html
@@ -1,5 +1,5 @@
 <fieldset>
-  <div lmis-page-view-report="app-config_partials_forms_facility-info" class="row">
+  <div class="row">
     <div class="col-sm-6">
       <div class="form-group"
            ng-class="{ 'has-error': (editAppConfigForm.appFacility).$invalid && isSubmitted }">

--- a/app/views/app-config/partials/forms/product-profile.html
+++ b/app/views/app-config/partials/forms/product-profile.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="app-config_partials_forms_product-profile" class="col-md-12">
+<div class="col-md-12">
 
   <div class="panel panel-default">
     <div class="panel-heading">

--- a/app/views/app-config/welcome-page.html
+++ b/app/views/app-config/welcome-page.html
@@ -11,7 +11,7 @@
     <div class="panel-body"></div>
     <div class="row">
       <div class="col-xs-4">
-        <a ui-sref="appConfig.wizard" lmis-analytics-directive="welcome" class="btn btn-success btn-lg" ng-click="loadingDeviceInfo = true"
+        <a ui-sref="appConfig.wizard" ga-click="welcome" class="btn btn-success btn-lg" ng-click="loadingDeviceInfo = true"
            ng-disabled="loadingDeviceInfo">
           <span ng-show="!loadingDeviceInfo" i18n="continue"></span>
           <span ng-show="!loadingDeviceInfo"><i class="fa fa-arrow-circle-right"></i></span>

--- a/app/views/app-config/welcome-page.html
+++ b/app/views/app-config/welcome-page.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="app-config_welcome-page" class="panel panel-default">
+<div class="panel panel-default">
   <div class="panel-heading">
     <h4 class="panel-title" i18n="appConfigWelcomeMsg"></h4>
   </div>

--- a/app/views/app-config/wizard.html
+++ b/app/views/app-config/wizard.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="app-config_wizard" class="row" ng-show="currentStep === STEP_ONE">
+<div class="row" ng-show="currentStep === STEP_ONE">
   <div class="col-sm-12">
     <div class="alert alert-info">
       <span i18n="configSetupInfo"></span>

--- a/app/views/app-config/wizard/partials/email-setup.html
+++ b/app/views/app-config/wizard/partials/email-setup.html
@@ -31,13 +31,13 @@
 
     <div class="btn-group btn-group-justified">
       <div class="btn-group">
-        <a ui-sref="appConfigWelcome" lmis-analytics-directive="app_config_welcome" class="btn btn-default btn-lg btn-left">
+        <a ui-sref="appConfigWelcome" ga-click="app_config_welcome" class="btn btn-default btn-lg btn-left">
           <span><i class="fa fa-arrow-circle-left"></i></span>
           <span i18n="back"></span>
         </a>
       </div>
       <div class="btn-group">
-        <button type="submit" lmis-analytics-directive="email_submit" class="btn btn-success btn-lg btn-right" ng-disabled="disableBtn" ng-click="isSubmitted = true">
+        <button type="submit" ga-click="email_submit" class="btn btn-success btn-lg btn-right" ng-disabled="disableBtn" ng-click="isSubmitted = true">
           <span ng-show="!disableBtn" i18n="continue"></span>
           <span ng-show="!disableBtn"><i class="fa fa-arrow-circle-right"></i></span>
           <span ng-show="disableBtn" i18n="loading"></span>

--- a/app/views/app-config/wizard/partials/facility-cce-profile-setup.html
+++ b/app/views/app-config/wizard/partials/facility-cce-profile-setup.html
@@ -7,13 +7,13 @@
     <div class="panel"></div>
     <div class="btn-group btn-group-justified">
           <div class="btn-group">
-            <button lmis-analytics-directive="facility_setup" type="button" class="btn btn-default btn-lg btn-left" ng-click="moveTo(STEP_FOUR)">
+            <button ga-click="facility_setup" type="button" class="btn btn-default btn-lg btn-left" ng-click="moveTo(STEP_FOUR)">
               <span><i class="fa fa-arrow-circle-left"></i></span>
               <span i18n="back"></span>
             </button>
           </div>
           <div class="btn-group">
-            <button type="submit" lmis-analytics-directive="ccu_setup" class="btn btn-success btn-lg btn-right" ng-click="save()" ng-disabled="isSaving">
+            <button type="submit" ga-click="ccu_setup" class="btn btn-success btn-lg btn-right" ng-click="save()" ng-disabled="isSaving">
               <span ng-if="!isSaving" i18n="save"></span>
               <span ng-if="!isSaving"><i class="fa fa-floppy-o"></i></i></span>
               <span ng-if="isSaving" i18n="saving"></span>

--- a/app/views/app-config/wizard/partials/facility-cce-profile-setup.html
+++ b/app/views/app-config/wizard/partials/facility-cce-profile-setup.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="app-config_partials_facility-cce-profile-setup" class="row">
+<div class="row">
   <div ng-include="'views/app-config/partials/forms/ccu-profile.html'"></div>
   <div ng-include="'views/app-config/wizard/partials/sequence-map.html'"></div>
 </div>

--- a/app/views/app-config/wizard/partials/facility-contact-person.html
+++ b/app/views/app-config/wizard/partials/facility-contact-person.html
@@ -16,13 +16,13 @@
       <div class="panel"></div>
         <div class="btn-group btn-group-justified">
           <div class="btn-group">
-            <button type="button" lmis-analytics-directive="contact_person" class="btn btn-default btn-lg btn-left" ng-click="moveTo(STEP_TWO)">
+            <button type="button" ga-click="contact_person" class="btn btn-default btn-lg btn-left" ng-click="moveTo(STEP_TWO)">
               <span><i class="fa fa-arrow-circle-left"></i></span>
               <span i18n="back"></span>
             </button>
           </div>
           <div class="btn-group">
-            <button type="submit" lmis-analytics-directive="facility" class="btn btn-success btn-lg btn-right" ng-click="isSubmitted = true">
+            <button type="submit" ga-click="facility" class="btn btn-success btn-lg btn-right" ng-click="isSubmitted = true">
               <span i18n="continue"></span>
               <span><i class="fa fa-arrow-circle-right"></i></span>
             </button>

--- a/app/views/app-config/wizard/partials/facility-contact-person.html
+++ b/app/views/app-config/wizard/partials/facility-contact-person.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="app-config_partials_facility-contact-person" class="panel panel-default">
+<div class="panel panel-default">
   <div class="panel-heading">
     <h4 class="panel-title" i18n="contactPersonInfo"></h4>
   </div>

--- a/app/views/app-config/wizard/partials/facility-info.html
+++ b/app/views/app-config/wizard/partials/facility-info.html
@@ -15,13 +15,13 @@
   <div class="col-sm-15">
     <div class="btn-group btn-group-justified">
       <div class="btn-group">
-        <button type="button" lmis-analytics-directive="favility_info" class="btn btn-default btn-lg btn-left" ng-click="moveTo(STEP_ONE)">
+        <button type="button" ga-click="favility_info" class="btn btn-default btn-lg btn-left" ng-click="moveTo(STEP_ONE)">
           <span><i class="fa fa-arrow-circle-left"></i></span>
           <span i18n="back"></span>
         </button>
       </div>
       <div class="btn-group">
-        <button type="submit" lmis-analytics-directive="sequence_map" class="btn btn-success btn-lg btn-right" ng-click="isSubmitted = true">
+        <button type="submit" ga-click="sequence_map" class="btn btn-success btn-lg btn-right" ng-click="isSubmitted = true">
           <span i18n="continue"></span>
           <span><i class="fa fa-arrow-circle-right"></i></span>
         </button>

--- a/app/views/app-config/wizard/partials/facility-info.html
+++ b/app/views/app-config/wizard/partials/facility-info.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="app-config_partials_facility-info" class="panel panel-default">
+<div class="panel panel-default">
   <div class="panel-heading">
     <h4 class="panel-title" i18n="facilityInfo"></h4>
   </div>

--- a/app/views/app-config/wizard/partials/facility-product-profile.html
+++ b/app/views/app-config/wizard/partials/facility-product-profile.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="app-config_partials_facility-product-profile" class="row">
+<div class="row">
   <div ng-include="'views/app-config/partials/forms/product-profile.html'"></div>
   <div ng-include="'views/app-config/wizard/partials/sequence-map.html'"></div>
 </div>

--- a/app/views/app-config/wizard/partials/facility-product-profile.html
+++ b/app/views/app-config/wizard/partials/facility-product-profile.html
@@ -7,13 +7,13 @@
     <div class="panel"></div>
     <div class="btn-group btn-group-justified">
       <div class="btn-group">
-        <button type="button" lmis-analytics-directive="product_profile" class="btn btn-default btn-lg btn-left" ng-click="moveTo(STEP_THREE)">
+        <button type="button" ga-click="product_profile" class="btn btn-default btn-lg btn-left" ng-click="moveTo(STEP_THREE)">
           <span><i class="fa fa-arrow-circle-left"></i></span>
           <span i18n="back"></span>
         </button>
       </div>
       <div class="btn-group">
-        <button type="submit" lmis-analytics-directive="sequence_map" class="btn btn-success btn-lg btn-right" ng-click="moveTo(STEP_FIVE)">
+        <button type="submit" ga-click="sequence_map" class="btn btn-success btn-lg btn-right" ng-click="moveTo(STEP_FIVE)">
           <span i18n="continue"></span>
           <span><i class="fa fa-arrow-circle-right"></i></span>
         </button>

--- a/app/views/app-config/wizard/partials/facility-survey.html
+++ b/app/views/app-config/wizard/partials/facility-survey.html
@@ -26,13 +26,13 @@
       <div class="col-md-18">
         <div class="btn-group btn-group-justified">
           <div class="btn-group">
-            <button type="button" lmis-analytics-directive="facility_survey" class="btn btn-default btn-lg btn-left" ng-click="moveTo(STEP_FOUR)">
+            <button type="button" ga-click="facility_survey" class="btn btn-default btn-lg btn-left" ng-click="moveTo(STEP_FOUR)">
               <span><i class="fa fa-arrow-circle-left"></i></span>
               <span i18n="back"></span>
             </button>
           </div>
           <div class="btn-group">
-            <button type="submit" lmis-analytics-directive="sequence_map" class="btn btn-success btn-lg btn-right" ng-click="save()" ng-disabled="isSaving">
+            <button type="submit" ga-click="sequence_map" class="btn btn-success btn-lg btn-right" ng-click="save()" ng-disabled="isSaving">
               <span ng-if="!isSaving" i18n="save"></span>
               <span ng-if="!isSaving"><i class="fa fa-floppy-o"></i></i></span>
               <span ng-if="isSaving" i18n="saving"></span>

--- a/app/views/app-config/wizard/partials/facility-survey.html
+++ b/app/views/app-config/wizard/partials/facility-survey.html
@@ -1,4 +1,4 @@
-<form lmis-page-view-report="app-config_partials_facility-survey" name="editAppConfigForm" ng-submit="editAppConfigForm.$valid" novalidate>
+<form name="editAppConfigForm" ng-submit="editAppConfigForm.$valid" novalidate>
   <div class="col-md-12">
     <div class="panel panel-default">
       <div class="panel-heading">

--- a/app/views/app-config/wizard/partials/sequence-map.html
+++ b/app/views/app-config/wizard/partials/sequence-map.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="app-config_partials_sequence-map" class="panel-body">
+<div class="panel-body">
   <div class="row">
     <div class="col-sm-12"><span class="badge alert-info">Step {{ currentStep }} of 5</span></div>
   </div>

--- a/app/views/batches/add-batch-form.html
+++ b/app/views/batches/add-batch-form.html
@@ -144,7 +144,7 @@
           </div>
 
           <div class="col-sm-3">
-            <button type="submit" lmis-analytics-directive="batch_form" class="btn btn-success btn-lg btn-block">Save</button>
+            <button type="submit" ga-click="batch_form" class="btn btn-success btn-lg btn-block">Save</button>
           </div>
         </div>
 

--- a/app/views/batches/add-batch-form.html
+++ b/app/views/batches/add-batch-form.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <form lmis-page-view-report="batches_add-batch-form" name="addProductItemForm" ng-submit="save()">
+  <form name="addProductItemForm" ng-submit="save()">
     <div class="col-sm-12">
       <div class="panel panel-default">
         <div class="panel-heading">

--- a/app/views/batches/index.html
+++ b/app/views/batches/index.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="batches_index" class="row">
+<div class="row">
   <div class="btn-group col-sm-2">
     <a ui-sref="addBatchView" lmis-analytics-directive="add_batch_view" class="btn btn-default">
       <span><i class="fa fa-plus"></i></span>

--- a/app/views/batches/index.html
+++ b/app/views/batches/index.html
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="btn-group col-sm-2">
-    <a ui-sref="addBatchView" lmis-analytics-directive="add_batch_view" class="btn btn-default">
+    <a ui-sref="addBatchView" ga-click="add_batch_view" class="btn btn-default">
       <span><i class="fa fa-plus"></i></span>
       <span>Add Batch</span></a>
   </div>

--- a/app/views/bundles/incoming-log.html
+++ b/app/views/bundles/incoming-log.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="bundles_incoming-log" class="row">
+<div class="row">
   <div class="col-sm-12">
     <div class="panel panel-default">
       <div class="panel-heading">

--- a/app/views/bundles/partials/bundle-lines.html
+++ b/app/views/bundles/partials/bundle-lines.html
@@ -40,7 +40,7 @@
 
     <div class="col-sm-4">
       <label i18n="storageUnit"></label>
-      <select class="form-control" lmis-analytics-directive="storage_unit" ng-model="logIncomingForm.storage_units[bundleLine.uuid]">
+      <select class="form-control" ga-click="storage_unit" ng-model="logIncomingForm.storage_units[bundleLine.uuid]">
         <option value="" i18n="addToStorageUnit"></option>
         <option ng-repeat="storageUnit in receivingFacilityStorageUnits"
                 value="{{ storageUnit.uuid }}"

--- a/app/views/bundles/partials/bundle-lines.html
+++ b/app/views/bundles/partials/bundle-lines.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="bundles_partials_bundle-lines" class="panel-heading">
+<div class="panel-heading">
   <h4 class="panel-title">{{ $index + 1 }}</h4>
 </div>
 <div class="panel-body">

--- a/app/views/bundles/partials/enter-bundle-no.html
+++ b/app/views/bundles/partials/enter-bundle-no.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="bundles_partials_enter-bundle-no" class="col-sm-12" ng-show="!show && clicked">
+<div class="col-sm-12" ng-show="!show && clicked">
   <br/>
 
   <div class="alert alert-danger">

--- a/app/views/bundles/partials/enter-bundle-no.html
+++ b/app/views/bundles/partials/enter-bundle-no.html
@@ -19,7 +19,7 @@
              type="text" name="bundleNo" id="bundleNo" ng-model="$parent.showBundleNo"
              placeholder="scan or type bundle number" required/>
       <span class="input-group-btn">
-        <button class="btn btn-info" lmis-analytics-directive="bundle" type="submit" i18n="showBundle"></button>
+        <button class="btn btn-info" ga-click="bundle" type="submit" i18n="showBundle"></button>
       </span>
     </div>
   </form>
@@ -33,7 +33,7 @@
       <label for="bundleNo">&nbsp;</label>
     </div>
   </div>
-  <a ui-sref="addNewInventory({bundleNo: $parent.showBundleNo})" lmis-analytics-directive="add_new_inventory" class="btn btn-success">
+  <a ui-sref="addNewInventory({bundleNo: $parent.showBundleNo})" ga-click="add_new_inventory" class="btn btn-success">
     <span><i class="fa fa-plus"></i></span>
     <span i18n="addNewInventory"></span>
   </a>

--- a/app/views/bundles/partials/log-automatically.html
+++ b/app/views/bundles/partials/log-automatically.html
@@ -54,7 +54,7 @@
               </div>
             </div>
             <div class="col-md-4 pull-right">
-              <button type="submit" lmis-analytics-directive="log" id="save" name="save" class="btn btn-success">
+              <button type="submit" ga-click="log" id="save" name="save" class="btn btn-success">
                 <span i18n="save"></span>
                 <i class="fa fa-save"></i>
               </button>

--- a/app/views/bundles/partials/log-automatically.html
+++ b/app/views/bundles/partials/log-automatically.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="bundles_partials_log-automatically" class="panel-body">
+<div class="panel-body">
   <div class="col-sm-12">
 
     <div class="panel panel-default">

--- a/app/views/bundles/partials/log-incoming-preview.html
+++ b/app/views/bundles/partials/log-incoming-preview.html
@@ -97,7 +97,7 @@
           </div>
         </div>
         <div class="col-md-4 pull-right">
-          <button type="button" lmis-analytics-directive="incoming_preview" id="preview" name="preview" class="btn btn-success">
+          <button type="button" ga-click="incoming_preview" id="preview" name="preview" class="btn btn-success">
             <span i18n="confirm" ng-click="confirm()"></span>
           </button>
         </div>

--- a/app/views/bundles/partials/log-incoming-preview.html
+++ b/app/views/bundles/partials/log-incoming-preview.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="bundles_partials_log-incoming-preview" class="col-sm-12">
+<div class="col-sm-12">
   <div class="panel panel-default">
     <div class="panel-heading">
       <h4 class="panel-title">Log Bundle Preview</h4>

--- a/app/views/bundles/partials/sequence-map.html
+++ b/app/views/bundles/partials/sequence-map.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="bundles_partials_sequence_map" class="col-sm-3">
+<div class="col-sm-3">
   <div class="info-box">
     <div ng-class="{'info-box-number' : true,
       'sequence-map-box' : currentStep !== LOG_STEPS.ENTER_BUNDLE_NO, 'alert-info' : currentStep === LOG_STEPS.ENTER_BUNDLE_NO }">1</div>

--- a/app/views/cold-chain-units/report-ccu-breakdown.html
+++ b/app/views/cold-chain-units/report-ccu-breakdown.html
@@ -15,7 +15,7 @@
                   <div class="form-group" ng-class="{ 'has-error': ((reportCCUBreakdownForm.ccuProfile).$error).required
                       && ccuBreakdown.isSubmitted }">
                     <label for="ccuProfile" i18n="selectCcu"></label>
-                    <select id="ccuProfile" lmis-analytics-directive="ccu_selection" name="ccuProfile" class="form-control" ng-model="ccuBreakdown.ccuProfile"
+                    <select id="ccuProfile" ga-click="ccu_selection" name="ccuProfile" class="form-control" ng-model="ccuBreakdown.ccuProfile"
                             required>
                       <option value="" i18n="selectFacultyCcu"></option>
                       <option ng-repeat="ccuProfile in facilityCcuList" value="{{ ccuProfile }}" required>
@@ -28,7 +28,7 @@
                   <div class="row">
                     <div class="panel-body"></div>
                     <div class="col-md-4 center-block">
-                      <button type="submit" id="send" lmis-analytics-directive="ccu_send" name="send" class="btn btn-lg btn-danger"
+                      <button type="submit" id="send" ga-click="ccu_send" name="send" class="btn btn-lg btn-danger"
                               ng-click="ccuBreakdown.isSubmitted = true" ng-disabled="isSaving">
                         <span ng-show="!isSaving" i18n="send"></span>
                         <span ng-show="!isSaving"><i class="fa fa-bullhorn"></i></span>

--- a/app/views/cold-chain-units/report-ccu-breakdown.html
+++ b/app/views/cold-chain-units/report-ccu-breakdown.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="bundles_partials_report-ccu-breakdown" class="row">
+<div class="row">
   <div class="col-sm-12">
     <div class="panel panel-default">
       <div class="panel-heading">

--- a/app/views/counter/counter-sample.html
+++ b/app/views/counter/counter-sample.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="counter_counter-sample" class="row">
+<div class="row">
   <div class="col-sm-12">
     <div class="col-sm-4">
       <label>drop down counter</label>

--- a/app/views/dashboard/dashboard.html
+++ b/app/views/dashboard/dashboard.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="dashboard_dashboard" ng-show="showChart">
+<div ng-show="showChart">
   <div ng-include="'views/dashboard/partials/stock-out-warning.html'"></div>
   <div class="panel panel-default">
     <div class="container-fluid">

--- a/app/views/dashboard/partials/stock-out-warning.html
+++ b/app/views/dashboard/partials/stock-out-warning.html
@@ -1,5 +1,5 @@
 <div ng-show="stockOutWarning.length">
-  <a ui-sref="multiStockOutBroadcast({productList: stockOutWarning.join(',')})" lmis-analytics-directive="stock_out">
+  <a ui-sref="multiStockOutBroadcast({productList: stockOutWarning.join(',')})" ga-click="stock_out">
     <div class="col-md-12 alert alert-danger">
       <img src="images/dashboard-icons/stock-out-warning.png" >
       <strong><span>{{ stockOutWarningMsg }}</span></strong>

--- a/app/views/dashboard/partials/stock-out-warning.html
+++ b/app/views/dashboard/partials/stock-out-warning.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="dashboard_partials_stock-out-warning" ng-show="stockOutWarning.length">
+<div ng-show="stockOutWarning.length">
   <a ui-sref="multiStockOutBroadcast({productList: stockOutWarning.join(',')})" lmis-analytics-directive="stock_out">
     <div class="col-md-12 alert alert-danger">
       <img src="images/dashboard-icons/stock-out-warning.png" >

--- a/app/views/facilities/facility_types.html
+++ b/app/views/facilities/facility_types.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="facilities_facility_types" class="row">
+<div class="row">
     <div class="col-sm-12">
         <div class="panel panel-default">
             <div class="panel-heading">

--- a/app/views/facilities/index.html
+++ b/app/views/facilities/index.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="facilities_index" class="row">
+<div class="row">
     <div class="col-lg-3 col-md-6">
         <a href="#/facilities/facility_types" lmis-analytics-directive="facility_types">
             <div class="box_stat box_ico">

--- a/app/views/facilities/index.html
+++ b/app/views/facilities/index.html
@@ -1,6 +1,6 @@
 <div class="row">
     <div class="col-lg-3 col-md-6">
-        <a href="#/facilities/facility_types" lmis-analytics-directive="facility_types">
+        <a href="#/facilities/facility_types" ga-click="facility_types">
             <div class="box_stat box_ico">
                 <span class="stat_ico stat_ico_1"><i class="fa fa-list"></i></span>
                 <h4>Facility Types</h4>

--- a/app/views/home/control-panel.html
+++ b/app/views/home/control-panel.html
@@ -1,4 +1,4 @@
-<accordion lmis-page-view-report="home_control_panel" close-others="true">
+<accordion close-others="true">
 
   <accordion-group>
     <accordion-heading>

--- a/app/views/home/dashboard.html
+++ b/app/views/home/dashboard.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="home_dashboard" ng-if="productsUnset">
+<div ng-if="productsUnset">
   <div class="alert alert-warning">
     <span i18n="productsUnset"></span>
     <a lmis-analytics-directive="home_settings_facility" ui-sref="home.index.settings.facility" class="alert-link"

--- a/app/views/home/dashboard.html
+++ b/app/views/home/dashboard.html
@@ -1,7 +1,7 @@
 <div ng-if="productsUnset">
   <div class="alert alert-warning">
     <span i18n="productsUnset"></span>
-    <a lmis-analytics-directive="home_settings_facility" ui-sref="home.index.settings.facility" class="alert-link"
+    <a ga-click="home_settings_facility" ui-sref="home.index.settings.facility" class="alert-link"
       i18n="inventorySettings">
     </a>
   </div>

--- a/app/views/home/dashboard/chart.html
+++ b/app/views/home/dashboard/chart.html
@@ -1,5 +1,4 @@
 <nvd3-multi-bar-horizontal-chart
-    lmis-page-view-report="home_dashboard_chart"
   id="inventory-chart"
   data="inventoryChart"
   tooltips="true"

--- a/app/views/home/dashboard/table.html
+++ b/app/views/home/dashboard/table.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="home_dashboard_table" ng-repeat="product in products">
+<div ng-repeat="product in products">
   <div class="col-sm-4">
     <div class="panel panel-default">
       <div class="panel-heading">

--- a/app/views/home/index.html
+++ b/app/views/home/index.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="home_nav" class="row">
+<div class="row">
   <div class="col-md-12">
     <h2 ng-bind="facility"></h2>
     <div ng-repeat="reminder in reminders">

--- a/app/views/home/main-activity.html
+++ b/app/views/home/main-activity.html
@@ -6,28 +6,28 @@
     </accordion-heading>
 
     <div class="col-md-3 col-xs-6 btn">
-      <a lmis-analytics-directive="stock_count" ui-sref="stockCountHome" id="t2">
+      <a ga-click="stock_count" ui-sref="stockCountHome" id="t2">
         <img src="images/dashboard-icons/stock-count.png" class="img-rounded">
         <span i18n="stockCount" class="main-activity-link"></span>
       </a>
     </div>
 
     <div class="col-md-3 col-xs-6 btn">
-      <a lmis-analytics-directive="discard_count_home" ui-sref="discardCountHome">
+      <a ga-click="discard_count_home" ui-sref="discardCountHome">
         <img src="images/dashboard-icons/add-waste-count.png" class="img-rounded">
         <span i18n="addWasteCount" class="main-activity-link"></span>
       </a>
     </div>
 
     <div class="col-md-3 col-xs-6 btn">
-      <a lmis-analytics-directive="stock_out_alert" ui-sref="broadcastStockOut">
+      <a ga-click="stock_out_alert" ui-sref="broadcastStockOut">
         <img src="images/dashboard-icons/stock-out-broadcast.png" class="img-rounded">
         <span i18n="stockOutBroadcast" class="main-activity-link"></span>
       </a>
     </div>
 
     <div class="col-md-3 col-xs-6 btn">
-      <a lmis-analytics-directive="report_ccu_breakdown" ui-sref="reportCcuBreakdown">
+      <a ga-click="report_ccu_breakdown" ui-sref="reportCcuBreakdown">
         <img src="images/dashboard-icons/ccu-breakdown.png" class="img-rounded">
         <span i18n="ccuBreakdown" class="main-activity-link"></span>
       </a>
@@ -42,7 +42,7 @@
     </accordion-heading>
 
     <div class="col-md-3 col-xs-6 btn">
-      <a lmis-analytics-directive="app_config" ui-sref="appConfig.edit">
+      <a ga-click="app_config" ui-sref="appConfig.edit">
         <img src="images/dashboard-icons/app-config.png" class="img-rounded">
         <span i18n="appConfig" class="main-activity-link"></span>
       </a>

--- a/app/views/home/main-activity.html
+++ b/app/views/home/main-activity.html
@@ -1,4 +1,4 @@
-<accordion lmis-page-view-report="home_main_activity" >
+<accordion>
   <accordion-group is-open="true">
     <accordion-heading>
       <span><i class="fa fa-user"></i></span>

--- a/app/views/home/partials/discard-count-reminder.html
+++ b/app/views/home/partials/discard-count-reminder.html
@@ -1,5 +1,5 @@
 <div ng-show="hasPendingDiscardCount">
-  <a lmis-analytics-directive="discard_count_form" ui-sref="discardCountForm">
+  <a ga-click="discard_count_form" ui-sref="discardCountForm">
     <div class="col-md-12 alert alert-warning">
       <img src="images/dashboard-icons/add-waste-count.png" class="img-rounded"/>
       <strong><span i18n="discardCountReminderMsg"></span></strong>

--- a/app/views/home/partials/discard-count-reminder.html
+++ b/app/views/home/partials/discard-count-reminder.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="home_partials_discard_count_reminder" ng-show="hasPendingDiscardCount">
+<div ng-show="hasPendingDiscardCount">
   <a lmis-analytics-directive="discard_count_form" ui-sref="discardCountForm">
     <div class="col-md-12 alert alert-warning">
       <img src="images/dashboard-icons/add-waste-count.png" class="img-rounded"/>

--- a/app/views/home/partials/stock-count-reminder.html
+++ b/app/views/home/partials/stock-count-reminder.html
@@ -1,5 +1,5 @@
 <div ng-show="$parent.isStockCountDue">
-  <a lmis-analytics-directive="stock_count_form" ui-sref="stockCountForm">
+  <a ga-click="stock_count_form" ui-sref="stockCountForm">
     <div class="col-md-12 alert alert-warning">
       <img src="images/dashboard-icons/add-stock-count.png" class="img-rounded"/>
       <strong><span i18n="stockCountReminderMsg"></span></strong>

--- a/app/views/home/partials/stock-count-reminder.html
+++ b/app/views/home/partials/stock-count-reminder.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="home_partials_stock_count_reminder" ng-show="$parent.isStockCountDue">
+<div ng-show="$parent.isStockCountDue">
   <a lmis-analytics-directive="stock_count_form" ui-sref="stockCountForm">
     <div class="col-md-12 alert alert-warning">
       <img src="images/dashboard-icons/add-stock-count.png" class="img-rounded"/>

--- a/app/views/home/partials/survey-reminder.html
+++ b/app/views/home/partials/survey-reminder.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="home_partials_survey_reminder" ng-show="pendingSurveys.length !== 0" ng-repeat="survey in pendingSurveys">
+<div ng-show="pendingSurveys.length !== 0" ng-repeat="survey in pendingSurveys">
   <a lmis-analytics-directive="take_survey" ui-sref="takeSurvey({surveyUUID: survey.uuid})" style="display: block">
     <div class="col-md-12 alert alert-warning">
       <i class="fa fa-exclamation-circle"></i>

--- a/app/views/home/partials/survey-reminder.html
+++ b/app/views/home/partials/survey-reminder.html
@@ -1,5 +1,5 @@
 <div ng-show="pendingSurveys.length !== 0" ng-repeat="survey in pendingSurveys">
-  <a lmis-analytics-directive="take_survey" ui-sref="takeSurvey({surveyUUID: survey.uuid})" style="display: block">
+  <a ga-click="take_survey" ui-sref="takeSurvey({surveyUUID: survey.uuid})" style="display: block">
     <div class="col-md-12 alert alert-warning">
       <i class="fa fa-exclamation-circle"></i>
       <strong><span ng-bind="survey.name"></span></strong>

--- a/app/views/home/settings.html
+++ b/app/views/home/settings.html
@@ -1,5 +1,5 @@
 <div>
-  <ul lmis-page-view-report="home_settings" class="nav nav-pills">
+  <ul class="nav nav-pills">
     <li ui-sref-active="active">
       <a ui-sref="home.index.settings.facility" lmis-analytics-directive="settings_facility" i18n="facility"></a>
     </li>

--- a/app/views/home/settings.html
+++ b/app/views/home/settings.html
@@ -1,17 +1,17 @@
 <div>
   <ul class="nav nav-pills">
     <li ui-sref-active="active">
-      <a ui-sref="home.index.settings.facility" lmis-analytics-directive="settings_facility" i18n="facility"></a>
+      <a ui-sref="home.index.settings.facility" ga-click="settings_facility" i18n="facility"></a>
     </li>
     <li ui-sref-active="active">
-      <a ui-sref="home.index.settings.inventory" lmis-analytics-directive="settings_inventory" i18n="inventory"></a>
+      <a ui-sref="home.index.settings.inventory" ga-click="settings_inventory" i18n="inventory"></a>
     </li>
   </ul>
 </div>
 
 <div class="row" ui-view></div>
 <div class="pull-right">
-  <button class="btn btn-default" lmis-analytics-directive="settings_reset" i18n="reset" />
-  <button type="submit" lmis-analytics-directive="settings_submit" class="btn btn-success"
+  <button class="btn btn-default" ga-click="settings_reset" i18n="reset" />
+  <button type="submit" ga-click="settings_submit" class="btn btn-success"
     i18n="submit" ng-click="save(settings)" />
 </div>

--- a/app/views/home/settings/facility.html
+++ b/app/views/home/settings/facility.html
@@ -1,4 +1,4 @@
-<form lmis-page-view-report="home_settings_facility" novalidate ng-submit="save()">
+<form novalidate ng-submit="save()">
   <div class="col-sm-4">
     <div class="form-group">
       <label for="name">Facility Name</label>

--- a/app/views/home/settings/inventory.html
+++ b/app/views/home/settings/inventory.html
@@ -1,4 +1,4 @@
-<form lmis-page-view-report="home_settings_inventory" novalidate ng-submit="save()">
+<form novalidate ng-submit="save()">
   <div class="row">
     <div class="container">
       <div class="col-sm-3">

--- a/app/views/home/sidebar.html
+++ b/app/views/home/sidebar.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="home_sidebar" class="panel panel-default">
+<div class="panel panel-default">
   <div class="panel-heading">
     <h3 class="panel-title">Alerts</h3>
   </div>

--- a/app/views/index/breadcrumbs.html
+++ b/app/views/index/breadcrumbs.html
@@ -1,5 +1,4 @@
 <tv-breadcrumbs
-    lmis-page-view-report="index_breadcrumbs"
   ng-hide="state.includes('home') || state.includes('appConfigWelcome')
     || state.includes('appConfig.wizard')"
   home="home.index.home.mainActivity">

--- a/app/views/index/footer.html
+++ b/app/views/index/footer.html
@@ -1,4 +1,4 @@
-<footer lmis-page-view-report="index_footer" id="footer">
+<footer id="footer">
   <div class="container">
     <small class="text-muted">
       <span ng-bind="'© ' + year"></span>

--- a/app/views/index/header.html
+++ b/app/views/index/header.html
@@ -1,13 +1,13 @@
 <header>
   <div class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="container">
-      <a ui-sref="home.index.home.mainActivity" lmis-analytics-directive="LoMIS" class="navbar-brand">
+      <a ui-sref="home.index.home.mainActivity" ga-click="LoMIS" class="navbar-brand">
         <span class="fa fa-home"></span>
         <span i18n="appName"></span>
       </a>
       <ul class="nav navbar-nav pull-right">
         <li>
-          <a lmis-analytics-directive="on_off_line_toggle">
+          <a ga-click="on_off_line_toggle">
             <span
               class="label"
               ng-class="{

--- a/app/views/index/header.html
+++ b/app/views/index/header.html
@@ -1,5 +1,5 @@
 <header>
-  <div lmis-page-view-report="index_header" class="navbar navbar-default navbar-fixed-top" role="navigation">
+  <div class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="container">
       <a ui-sref="home.index.home.mainActivity" lmis-analytics-directive="LoMIS" class="navbar-brand">
         <span class="fa fa-home"></span>

--- a/app/views/index/index.html
+++ b/app/views/index/index.html
@@ -1,4 +1,4 @@
-<a lmis-page-view-report="index_index" id="top"></a>
+<a id="top"></a>
 <div growl></div>
 <div ui-view="header"></div>
 

--- a/app/views/index/loading-fixture-screen.html
+++ b/app/views/index/loading-fixture-screen.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="index_loading_fixture_screen" class="modal-body center-block">
+<div class="modal-body center-block">
   <div class="row">
     <div class="col-md-12 center-text">
       <img src="images/lomis-512-splash.png" class="img-rounded splash-img">

--- a/app/views/inventory/add-inventory.html
+++ b/app/views/inventory/add-inventory.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="inventory_add-inventory" class="row">
+<div class="row">
   <div class="col-sm-12" ng-show="inventory.showForm" ng-include="'views/inventory/forms/partials/add-form.html'"></div>
   <div class="col-sm-12" ng-show="!inventory.showForm"
        ng-include="'views/inventory/partials/preview-add-inventory.html'"></div>

--- a/app/views/inventory/forms/partials/add-form.html
+++ b/app/views/inventory/forms/partials/add-form.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="inventory_forms_partials_add-form" class="panel panel-default">
+<div class="panel panel-default">
   <div class="panel-heading">
     <h4 class="panel-title">Add New Inventory</h4>
   </div>

--- a/app/views/inventory/forms/partials/add-inventory-line.html
+++ b/app/views/inventory/forms/partials/add-inventory-line.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="inventory_forms_partials_add-inventory-line" class="panel panel-default">
+<div class="panel panel-default">
   <div class="panel-heading">
     <h4 class="panel-title">
       <span class="removeIcon" title="click to remove this row.">

--- a/app/views/inventory/index.html
+++ b/app/views/inventory/index.html
@@ -1,13 +1,13 @@
 <div class="row">
   <div class="col-sm-12">
     <div class="btn-group col-sm-2">
-      <a ui-sref="addInventory" lmis-analytics-directive="add_inventory" class="btn btn-default">
+      <a ui-sref="addInventory" ga-click="add_inventory" class="btn btn-default">
         <span><i class="fa fa-plus"></i></span>
         <span i18n="addNewInventory"></span>
       </a>
     </div>
     <div class="btn-group col-sm-2">
-      <a ui-sref="incomingLog" lmis-analytics-directive="incoming_log" class="btn btn-default">
+      <a ui-sref="incomingLog" ga-click="incoming_log" class="btn btn-default">
         <span><i class="fa fa-plus"></i></span>
         <span i18n="incomingLog"></span>
       </a>

--- a/app/views/inventory/index.html
+++ b/app/views/inventory/index.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="inventory_index" class="row">
+<div class="row">
   <div class="col-sm-12">
     <div class="btn-group col-sm-2">
       <a ui-sref="addInventory" lmis-analytics-directive="add_inventory" class="btn btn-default">

--- a/app/views/inventory/partials/add-inventory-line.html
+++ b/app/views/inventory/partials/add-inventory-line.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="inventory_partials_add-inventory-line" class="panel panel-default">
+<div class="panel panel-default">
   <div class="panel-heading">
     <h4 class="panel-title">
       <span class="removeIcon" title="click to remove this row.">

--- a/app/views/inventory/partials/preview-add-inventory.html
+++ b/app/views/inventory/partials/preview-add-inventory.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="inventory_partials_preview-add-inventory" class="panel panel-default">
+<div class="panel panel-default">
   <div class="panel-heading">
     <h4 class="panel-title">Preview New Inventory</h4>
   </div>

--- a/app/views/inventory/partials/preview-inventory-line.html
+++ b/app/views/inventory/partials/preview-inventory-line.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="inventory_partials_preview-inventory-line" class="panel panel-default">
+<div class="panel panel-default">
   <div class="panel-heading">
     <h4 class="panel-title">
       <span>

--- a/app/views/notification-service/confirm-dialog.html
+++ b/app/views/notification-service/confirm-dialog.html
@@ -25,10 +25,10 @@
 </div>
 <div class="modal-footer" ng-show="headerMessage === ''">
   <span ng-bind="bodyMessage"></span>
-  <button class="btn btn-success" lmis-analytics-directive="dialog_confirm" ng-click="confirm(true)">
+  <button class="btn btn-success" ga-click="dialog_confirm" ng-click="confirm(true)">
     <span ng-bind="confirmBtnMsg"></span>
   </button>
-  <button class="btn btn-default" lmis-analytics-directive="dialog_cancel" ng-click="cancel(dismissMessage)">
+  <button class="btn btn-default" ga-click="dialog_cancel" ng-click="cancel(dismissMessage)">
     <span ng-bind="cancelBtnMsg"></span>
   </button>
 </div>

--- a/app/views/orders/place-order.html
+++ b/app/views/orders/place-order.html
@@ -19,7 +19,7 @@
                       <div class="col-sm-6">
                         <div class="form-group">
                           <label for="sendingFacility" i18n="sendingFacility"></label>
-                          <select id="sendingFacility" lmis-analytics-directive="facility_select" class="form-control" ng-model="order.sending_facility"
+                          <select id="sendingFacility" ga-click="facility_select" class="form-control" ng-model="order.sending_facility"
                                   required>
                             <option value="" i18n="selectSendingFacility"></option>
                             <option ng-repeat="facility in storage.facilities" value="{{ facility.uuid }}"
@@ -83,7 +83,7 @@
                           <tr ng-repeat="orderLine in order.order_lines">
                             <td ng-bind="($index + 1)"></td>
                             <td>
-                              <select ng-model="orderLine.productType" lmis-analytics-directive="orderline_product_type" class="form-control" required="">
+                              <select ng-model="orderLine.productType" ga-click="orderline_product_type" class="form-control" required="">
                                 <option value="" i18n="selectProductType"></option>
                                 <option ng-repeat="type in storage.productTypes" value="{{ type.uuid }}"
                                         ng-selected="{{ (orderLine.productType).uuid === type.uuid}}"
@@ -92,7 +92,7 @@
                               </select>
                             </td>
                             <td>
-                              <select ng-model="orderLine.program" lmis-analytics-directive="orderline_program" class="form-control" required>
+                              <select ng-model="orderLine.program" ga-click="orderline_program" class="form-control" required>
                                 <option value="" i18n="selectProgram"></option>
                                 <option ng-repeat="program in storage.programs" value="{{ program.uuid }}"
                                         ng-selected="{{ order.program === program.uuid}}"
@@ -104,7 +104,7 @@
                                      ng-model="orderLine.quantity" required/>
                             </td>
                             <td>
-                              <select class="form-control" lmis-analytics-directive="UOM_select" ng-model="orderLine.uom" required>
+                              <select class="form-control" ga-click="UOM_select" ng-model="orderLine.uom" required>
                                 <option value="" i18n="selectUOM"></option>
                                 <option ng-repeat="uom in storage.uomList" value="{{ uom.uuid }}" ng-bind="uom.name"
                                         ng-selected="{{ (orderLine.uom).uuid === uom.uuid }}"></option>

--- a/app/views/partials/group_about_to_expire_in_months.html
+++ b/app/views/partials/group_about_to_expire_in_months.html
@@ -1,4 +1,4 @@
-<select lmis-analytics-directive="months_select" id="orderByMonths" class="form-control" ng-model="$parent.orderByMonths" required>
+<select ga-click="months_select" id="orderByMonths" class="form-control" ng-model="$parent.orderByMonths" required>
   <option value="">-- select months to check for expiration --</option>
   <option value="6">6 months</option>
   <option value="5">5 months</option>

--- a/app/views/partials/notifications.html
+++ b/app/views/partials/notifications.html
@@ -28,8 +28,8 @@
     <div class="dropdown_footer">
       <a href="#" class="btn btn-sm btn-default">Show all</a>
       <div class="pull-right dropdown_actions">
-        <a href="#" lmis-analytics-directive="refresh"><i class="fa fa-refresh"></i></a>
-        <a href="#" lmis-analytics-directive="cog"><i class="fa fa-cog"></i></a>
+        <a href="#" ga-click="refresh"><i class="fa fa-refresh"></i></a>
+        <a href="#" ga-click="cog"><i class="fa fa-cog"></i></a>
       </div>
     </div>
   </li>

--- a/app/views/partials/search.html
+++ b/app/views/partials/search.html
@@ -1,7 +1,7 @@
 <div class="input-group">
   <input type="text" class="form-control" placeholder="Search" ng-model="$parent.search">
   <div class="input-group-btn">
-    <button lmis-analytics-directive="search" class="btn btn-default">
+    <button ga-click="search" class="btn btn-default">
       <i class="fa fa-search"></i>
     </button>
   </div>

--- a/app/views/product-types/add-product-type.html
+++ b/app/views/product-types/add-product-type.html
@@ -31,7 +31,7 @@
 
               <div class="form-group">
                 <label for="productCategory">Product Category</label>
-                <select lmis-analytics-directive="product_category" id="productCategory" class="form-control" ng-model="product.category" required>
+                <select ga-click="product_category" id="productCategory" class="form-control" ng-model="product.category" required>
                   <option value="">-- select product category --</option>
                   <option ng-repeat="category in categories" value="{{ category.uuid }}">
                     {{ category.name }}
@@ -41,7 +41,7 @@
 
               <div class="form-group">
                 <label for="baseUOM">Product Unit Of Measurement</label>
-                <select lmis-analytics-directive="base_UOM" id="baseUOM" class="form-control" ng-model="product.base_uom" required>
+                <select ga-click="base_UOM" id="baseUOM" class="form-control" ng-model="product.base_uom" required>
                   <option value="">-- select product unit of measurement --</option>
                   <option ng-repeat="uom in uomList" value="{{uom.uuid}}">
                     {{uom.name}}
@@ -64,7 +64,7 @@
               </div>
 
               <div class="col-sm-4">
-                <button lmis-analytics-directive="product_save" type="submit" class="btn btn-success btn-lg btn-block">Save</button>
+                <button ga-click="product_save" type="submit" class="btn btn-success btn-lg btn-block">Save</button>
               </div>
             </div>
           </div>

--- a/app/views/product-types/product-types-list.html
+++ b/app/views/product-types/product-types-list.html
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="btn-group col-sm-2">
-    <a lmis-analytics-directive="add_product_type" ui-sref="addProductTypeView" class="btn btn-default">
+    <a ga-click="add_product_type" ui-sref="addProductTypeView" class="btn btn-default">
       <span><i class="fa fa-plus"></i></span>
       <span i18n="addProductType"></span>
     </a>

--- a/app/views/programs/product_profile.html
+++ b/app/views/programs/product_profile.html
@@ -2,7 +2,7 @@
   <div class="col-sm-12">
 
     <div class="btn-group col-sm-2">
-      <a lmis-analytics-directive="product_profile_form" href="#/main/product_profile_form" class="btn btn-default"><i class="fa fa-plus-circle"></i> Add Product
+      <a ga-click="product_profile_form" href="#/main/product_profile_form" class="btn btn-default"><i class="fa fa-plus-circle"></i> Add Product
         Profile</a>
     </div>
   </div>

--- a/app/views/programs/product_profile_form.html
+++ b/app/views/programs/product_profile_form.html
@@ -22,7 +22,7 @@
 
               <div class="form-group">
                 <label for="product">Product</label>
-                <select lmis-analytics-directive="product_profile" id="product" class="form-control" ng-model="productProfile.product" required>
+                <select ga-click="product_profile" id="product" class="form-control" ng-model="productProfile.product" required>
                   <option value="">-- select product --</option>
                   <option ng-repeat="product in products" value="{{ product.uuid }}">
                     {{product.name }}
@@ -32,7 +32,7 @@
 
               <div class="form-group">
                 <label for="presentation">Presentation</label>
-                <select lmis-analytics-directive="presentation" id="presentation" class="form-control" ng-model="productProfile.presentation" required>
+                <select ga-click="presentation" id="presentation" class="form-control" ng-model="productProfile.presentation" required>
                   <option value="">-- select product presentation --</option>
                   <option ng-repeat="presentation in presentations" value="{{ presentation.uuid }}">
                     {{ presentation.name }}
@@ -42,7 +42,7 @@
 
               <div class="form-group">
                 <label for="formulation">Formulation</label>
-                <select lmis-analytics-directive="formulation" id="formulation" class="form-control" ng-model="productProfile.formulation" required>
+                <select ga-click="formulation" id="formulation" class="form-control" ng-model="productProfile.formulation" required>
                   <option value="">-- select product formulation --</option>
                   <option ng-repeat="formulation in formulations" value="{{ formulation.uuid }}">
                     {{ formulation.name }}
@@ -52,7 +52,7 @@
 
               <div class="form-group">
                 <label for="modeOfUse">Mode Of Administration</label>
-                <select lmis-analytics-directive="mode_of_use" id="modeOfUse" class="form-control" ng-model="productProfile.mode_of_use" required>
+                <select ga-click="mode_of_use" id="modeOfUse" class="form-control" ng-model="productProfile.mode_of_use" required>
                   <option value="">-- select mode of use --</option>
                   <option ng-repeat="mode in modes" value="{{ mode.uuid }}">
                     {{mode.name }}
@@ -74,7 +74,7 @@
 
               <div class="form-group">
                 <label for="volumeUOM">Volume Unit Of Measurement</label>
-                <select lmis-analytics-directive="volume_uom" id="volumeUOM" class="form-control" ng-model="productProfile.volume_uom" required>
+                <select ga-click="volume_uom" id="volumeUOM" class="form-control" ng-model="productProfile.volume_uom" required>
                   <option value="">-- select volume unit of measurement --</option>
                   <option ng-repeat="uom in uomList" value="{{uom.uuid}}">
                     {{uom.name}}
@@ -89,7 +89,7 @@
               </div>
 
               <div class="col-sm-4">
-                <button lmis-analytics-directive="product_profile_submit" type="submit" class="btn btn-success btn-lg btn-block">Save</button>
+                <button ga-click="product_profile_submit" type="submit" class="btn btn-success btn-lg btn-block">Save</button>
               </div>
             </div>
           </div>

--- a/app/views/programs/program_form.html
+++ b/app/views/programs/program_form.html
@@ -18,7 +18,7 @@
                             </div>
                             <div class="form-group">
                                 <label>Parent Program</label>
-                                <select lmis-analytics-directive="parent_program_select" class="form-control" ng-model="program.parent">
+                                <select ga-click="parent_program_select" class="form-control" ng-model="program.parent">
                                     <option value="">-- select parent program</option>
                                     <option ng-repeat="row in programList" value="{{ row.uuid }}">{{ row.name }}</option>
                                 </select>

--- a/app/views/programs/program_product_form.html
+++ b/app/views/programs/program_product_form.html
@@ -10,14 +10,14 @@
                         <div class="col-sm-4">
                             <div class="form-group">
                                 <label for="program">Program</label>
-                                <select lmis-analytics-directive="program" id="program" class="form-control" name="program" ng-model="program_product.program">
+                                <select ga-click="program" id="program" class="form-control" name="program" ng-model="program_product.program">
                                     <option value="">-- select program --</option>
                                     <option ng-repeat="row in programList" value="{{ row.uuid }}">{{ row.name }}</option>
                                 </select>
                             </div>
                             <div class="form-group">
                                 <label for="product">Product</label>
-                                <select lmis-analytics-directive="product" id="product" class="form-control" name="product" ng-model="program_product.product">
+                                <select ga-click="product" id="product" class="form-control" name="product" ng-model="program_product.product">
                                     <option value="">-- select product --</option>
                                     <option ng-repeat="row in productList" value="{{ row.uuid }}">{{ row.name }}</option>
                                 </select>
@@ -32,14 +32,14 @@
                             </div>
                             <div class="form-group">
                                 <label for="priceCurrency">Currency</label>
-                                <select lmis-analytics-directive="price_currency" id="priceCurrency" class="form-control" name="price_currency" ng-model="program_product.price_currency">
+                                <select ga-click="price_currency" id="priceCurrency" class="form-control" name="price_currency" ng-model="program_product.price_currency">
                                     <option value="">-- select currency --</option>
                                     <option ng-repeat="row in priceCurrencyList" value="{{ row.uuid }}">{{ row.name }}</option>
                                 </select>
                             </div>
                             <div class="form-group">
                                 <label for="fundingSource">Funding Source</label>
-                                <select lmis-analytics-directive="funding_source" id="fundingSource" class="form-control" name="funding_source" ng-model="program_product.funding_source">
+                                <select ga-click="funding_source" id="fundingSource" class="form-control" name="funding_source" ng-model="program_product.funding_source">
                                     <option value="">-- select funding source --</option>
                                     <option ng-repeat="row in companyList" value="{{ row.uuid }}">{{ row.name }}</option>
                                 </select>

--- a/app/views/reminder/reminder-notification.html
+++ b/app/views/reminder/reminder-notification.html
@@ -1,5 +1,5 @@
 <div>
-  <a lmis-analytics-directive="reminder" ui-sref="{{ reminder.link }}">
+  <a ga-click="reminder" ui-sref="{{ reminder.link }}">
     <div ng-class="{'alert': true, 'col-md-12': true, 'alert-info': reminder.type === 'info',
       'alert-warning': reminder.type === 'warning', 'alert-danger': reminder.type === 'danger',
       'alert-success': reminder.type === 'success' }">

--- a/app/views/stock-out-broadcast/multi-stock-out-broadcast.html
+++ b/app/views/stock-out-broadcast/multi-stock-out-broadcast.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="stock-out-broadcast_multi-stock-out-broadcast" class="row">
+<div class="row">
   <div class="col-sm-12">
     <div class="panel panel-default">
       <div class="panel-heading">

--- a/app/views/stock-out-broadcast/partials/confirm-stock-out-broadcast.html
+++ b/app/views/stock-out-broadcast/partials/confirm-stock-out-broadcast.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="stock-out-broadcast_partials_confirm-stock-out-broadcast" class="modal-header alert-danger">
+<div class="modal-header alert-danger">
   <span ng-bind="headerMessage"></span>
   <span class="pull-right" ng-click="cancel()">
     <i class="fa fa-times"></i>

--- a/app/views/stock-out-broadcast/stock-out-broadcast.html
+++ b/app/views/stock-out-broadcast/stock-out-broadcast.html
@@ -1,4 +1,4 @@
-<div lmis-page-view-report="stock-out-broadcast_stock-out-broadcast" class="row">
+<div class="row">
   <div class="col-sm-12">
     <div class="panel panel-default">
       <div class="panel-heading">

--- a/app/views/stock-out-broadcast/stock-out-broadcast.html
+++ b/app/views/stock-out-broadcast/stock-out-broadcast.html
@@ -15,7 +15,7 @@
                   <div class="form-group" ng-class="{ 'has-error': ((stockOutBroadcastForm.productType).$error).required
                       && stockOutForm.isSubmitted }">
                     <label for="productType" i18n="selectProductType"></label>
-                    <select lmis-analytics-directive="product_type_select" id="productType" name="productType" class="form-control" ng-model="stockOutForm.productType"
+                    <select ga-click="product_type_select" id="productType" name="productType" class="form-control" ng-model="stockOutForm.productType"
                             required>
                       <option value="" i18n="selectProductType"></option>
                       <option ng-repeat="productType in productTypes" value="{{ productType }}" required>
@@ -28,7 +28,7 @@
                   <div class="row">
                     <div class="panel-body"></div>
                     <div class="col-md-4 center-block">
-                      <button lmis-analytics-directive="stock_out_submit" type="submit" id="send" name="send" class="btn btn-lg btn-danger"
+                      <button ga-click="stock_out_submit" type="submit" id="send" name="send" class="btn btn-lg btn-danger"
                               ng-click="stockOutForm.isSubmitted = true" ng-disabled="isSaving">
                         <span ng-show="!isSaving" i18n="send"></span>
                         <span ng-show="!isSaving"><i class="fa fa-bullhorn"></i></span>

--- a/app/views/survey/take-survey.html
+++ b/app/views/survey/take-survey.html
@@ -1,4 +1,4 @@
-<form lmis-page-view-report="survey_take_survey" name="surveyForm" ng-submit="surveyForm.$valid" novalidate>
+<form name="surveyForm" ng-submit="surveyForm.$valid" novalidate>
   <div class="col-md-12">
     <div class="panel panel-default">
       <div class="panel-heading">

--- a/app/views/survey/take-survey.html
+++ b/app/views/survey/take-survey.html
@@ -29,13 +29,13 @@
       <div class="panel-body">
         <div class="btn-group btn-group-justified">
           <div class="btn-group">
-            <button type="button" lmis-analytics-directive="survey_submit" class="btn btn-default btn-lg btn-left" ng-click="clear()" ng-disabled="isSaving">
+            <button type="button" ga-click="survey_submit" class="btn btn-default btn-lg btn-left" ng-click="clear()" ng-disabled="isSaving">
               <span i18n="clear"></span>
               <span><i class="fa fa-refresh"></i></span>
             </button>
           </div>
           <div class="btn-group">
-            <button type="submit" lmis-analytics-directive="survey_save" class="btn btn-success btn-lg btn-right" ng-click="save()" ng-disabled="isSaving">
+            <button type="submit" ga-click="survey_save" class="btn btn-success btn-lg btn-right" ng-click="save()" ng-disabled="isSaving">
               <span ng-show="!isSaving" i18n="save"></span>
               <span ng-show="!isSaving"><i class="fa fa-floppy-o"></i></i></span>
               <span ng-show="isSaving" i18n="saving"></span>

--- a/test/spec/services/tracking-factory.js
+++ b/test/spec/services/tracking-factory.js
@@ -12,8 +12,8 @@ describe('Service: trackingFactory ', function() {
     trackingFactory = _trackingFactory_;
   }));
 
-  it('should define a tracker function', function() {
-    expect(angular.isFunction(trackingFactory.tracker)).toBe(true);
+  iit('should define a tracker property', function() {
+    expect('tracker' in trackingFactory).toBe(true);
   });
 
 });


### PR DESCRIPTION
Instead of annotating each view, we can leverage UI Router's [state change
events](https://github.com/angular-ui/ui-router/wiki#state-change-events) to track which views are viewed.

Attaching a directive to each view is costly and increases maintenance burden.

Rename click tracker to `gaClick` (Google Analytics click) for clarity and for familiarity with other Angular directives (e.g. `ngClick`).
