### PR TITLE
Decouple DB list from storage, closes item:694

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,6 +6,9 @@ module.exports = function(grunt) {
   // Load grunt tasks automatically
   require('load-grunt-tasks')(grunt);
 
+  // Load custom tasks
+  grunt.loadTasks('tasks');
+
   // Time how long tasks take. Can help when optimizing build times
   require('time-grunt')(grunt);
 
@@ -47,6 +50,10 @@ module.exports = function(grunt) {
           '<%= yeoman.app %>/scripts/{,*/}*.js',
           '<%= yeoman.app %>/scripts/fixtures/*.json'
         ]
+      },
+      fixtures: {
+        files: ['<%= yeoman.app %>/scripts/fixtures/*.json'],
+        tasks: ['fixtures']
       }
     },
 
@@ -440,6 +447,18 @@ module.exports = function(grunt) {
 
     jscs: {
       src: '<%= jshint.all %>'
+    },
+
+    fixtures: {
+      all: {
+        options: {
+          dest: '<%= yeoman.app %>/scripts/db.js'
+        },
+        files: [{
+          expand: true,
+          src: '<%= yeoman.app %>/scripts/fixtures/*.json'
+        }]
+      }
     }
   });
 
@@ -452,6 +471,7 @@ module.exports = function(grunt) {
       'clean:server',
       'wiredep',
       'ngconstant:development',
+      'fixtures',
       'concurrent:server',
       'autoprefixer',
       'connect:livereload',
@@ -481,7 +501,8 @@ module.exports = function(grunt) {
       'clean:dist',
       'wiredep',
       'ngconstant:production',
-      'chromeManifest:dist'
+      'chromeManifest:dist',
+      'fixtures'
     ];
 
     var release = [

--- a/app/index.html
+++ b/app/index.html
@@ -39,6 +39,7 @@
   <!-- build:js({.tmp,app}) scripts/scripts.js -->
   <script src="scripts/app.js"></script>
   <script src="scripts/config.js"></script>
+  <script src="scripts/db.js"></script>
   <script src="scripts/controllers/home.js"></script>
   <script src="scripts/controllers/stock-count.js"></script>
   <script src="scripts/controllers/stock-count-sync-stat.js"></script>

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -8,7 +8,8 @@ angular.module('lmisChromeApp', [
   'config',
   'nvd3ChartDirectives',
   'angular-growl',
-  'ngAnimate'
+  'ngAnimate',
+  'db'
 ])
   .run(function(storageService, $rootScope, $state, $window, appConfigService, fixtureLoaderService, growl) {
 

--- a/app/scripts/controllers/batches.js
+++ b/app/scripts/controllers/batches.js
@@ -84,11 +84,11 @@ angular.module('lmisChromeApp')
         $scope.companies = companyList;
       });
 
-      storageService.get(storageService.CURRENCY).then(function (currencyList) {
+      storageService.get(storageService.CURRENCIES).then(function (currencyList) {
         $scope.currencies = currencyList;
       });
 
-      storageService.get(storageService.CURRENCY).then(function (currencyList) {
+      storageService.get(storageService.CURRENCIES).then(function (currencyList) {
         $scope.currencies = currencyList;
       });
 
@@ -96,7 +96,7 @@ angular.module('lmisChromeApp')
         $scope.modes = modeOfAdministrationList;
       });
 
-      storageService.get(storageService.PRODUCT_FORMULATION).then(function (formulationList) {
+      storageService.get(storageService.PRODUCT_FORMULATIONS).then(function (formulationList) {
         $scope.formulations = formulationList;
       });
 
@@ -104,7 +104,7 @@ angular.module('lmisChromeApp')
         $scope.uomList = uomList;
       });
 
-      storageService.get(storageService.PRODUCT_PROFILE).then(function (data) {
+      storageService.get(storageService.PRODUCT_PROFILES).then(function (data) {
         $scope.profileList = data;
       });
 
@@ -117,7 +117,7 @@ angular.module('lmisChromeApp')
        * local storage.
        */
       $scope.save = function () {
-        storageService.save(storageService.BATCH, $scope.productItem).then(function () {
+        storageService.save(storageService.BATCHES, $scope.productItem).then(function () {
           $location.path('/batches/');
         });
       };

--- a/app/scripts/controllers/orders.js
+++ b/app/scripts/controllers/orders.js
@@ -31,7 +31,7 @@ angular.module('lmisChromeApp').config(function ($stateProvider) {
             return userFactory.getLoggedInUser();
           },
           programs: function (storageService) {
-            return storageService.get(storageService.PROGRAM);
+            return storageService.get(storageService.PROGRAMS);
           },
         },
         controller: function ($scope, $filter, currentFacility, uomList, productTypes, facilities, loggedInUser, programs, $stateParams, $state, ordersFactory) {

--- a/app/scripts/controllers/programs.js
+++ b/app/scripts/controllers/programs.js
@@ -2,7 +2,7 @@
 
 angular.module('lmisChromeApp')
   .controller('ProgramsCtrl', function($scope, storageService) {
-    storageService.get(storageService.PROGRAM).then(function(programs) {
+    storageService.get(storageService.PROGRAMS).then(function(programs) {
       $scope.programList = programs;
     });
   })
@@ -12,7 +12,7 @@ angular.module('lmisChromeApp')
     $scope.uuid = ($location.search()).uuid;
 
     if ($scope.uuid) {
-      storageService.loadTableObject(storageService.PROGRAM).then(function(
+      storageService.loadTableObject(storageService.PROGRAMS).then(function(
         programs) {
         $scope.program = programs[$scope.uuid];
       });
@@ -21,7 +21,7 @@ angular.module('lmisChromeApp')
 
     $scope.saveProgram = function() {
       if (Object.keys($scope.program).length > 0) {
-        storageService.save(storageService.PROGRAM, $scope.program).then(
+        storageService.save(storageService.PROGRAMS, $scope.program).then(
           function() {
             var msg = ($scope.uuid) ? {
               message: 'Program update was successful'
@@ -36,18 +36,18 @@ angular.module('lmisChromeApp')
       }
     };
 
-    storageService.get(storageService.PROGRAM).then(function(programs) {
+    storageService.get(storageService.PROGRAMS).then(function(programs) {
       $scope.programList = programs;
     });
 
     $scope.removeProgram = function(uuid) {
       console.log(uuid);
-      utility.loadTableObject(storageService.PROGRAM).then(function(programs) {
+      utility.loadTableObject(storageService.PROGRAMS).then(function(programs) {
         $scope.program = programs[uuid];
         // jshint camelcase: false
         var index = $scope.program.array_index;
         $scope.programList.splice(index, 1);
-        storageService.add(storageService.PROGRAM, $scope.programList);
+        storageService.add(storageService.PROGRAMS, $scope.programList);
       });
     };
   })
@@ -58,7 +58,7 @@ angular.module('lmisChromeApp')
       programProducts) {
       $scope.programProductList = programProducts;
     });
-    storageService.loadTableObject(storageService.PROGRAM).then(function(
+    storageService.loadTableObject(storageService.PROGRAMS).then(function(
       programs) {
       $scope.programs_object = programs;
     });
@@ -66,7 +66,7 @@ angular.module('lmisChromeApp')
       products) {
       $scope.products_object = products;
     });
-    storageService.loadTableObject(storageService.CURRENCY).then(function(
+    storageService.loadTableObject(storageService.CURRENCIES).then(function(
       currency) {
       $scope.currency_object = currency;
     });
@@ -78,7 +78,7 @@ angular.module('lmisChromeApp')
 
   .controller('programProductFormCtrl', function($scope, storageService, $location, growl) {
 
-    storageService.get(storageService.PROGRAM).then(function(programs) {
+    storageService.get(storageService.PROGRAMS).then(function(programs) {
       $scope.programList = programs;
     });
 
@@ -140,7 +140,7 @@ angular.module('lmisChromeApp')
 
   .controller('ProductProfileListCtrl', function($scope, storageService, $filter,
     ngTableParams) {
-    storageService.get(storageService.PRODUCT_PROFILE).then(function(data) {
+    storageService.get(storageService.PRODUCT_PROFILES).then(function(data) {
       // Table defaults
       var params = {
         page: 1,
@@ -176,7 +176,7 @@ angular.module('lmisChromeApp')
       $scope.uomList = data;
     });
 
-    storageService.get(storageService.PRODUCT_FORMULATION).then(function(data) {
+    storageService.get(storageService.PRODUCT_FORMULATIONS).then(function(data) {
       $scope.formulations = data;
     });
 
@@ -200,7 +200,7 @@ angular.module('lmisChromeApp')
         $scope.presentations = data;
       });
 
-    storageService.loadTableObject(storageService.PRODUCT_FORMULATION).then(
+    storageService.loadTableObject(storageService.PRODUCT_FORMULATIONS).then(
       function(data) {
         $scope.formulations = data;
       });

--- a/app/scripts/db.js
+++ b/app/scripts/db.js
@@ -1,0 +1,42 @@
+'use strict';
+
+angular.module('db', [])
+
+.constant('collections', {
+  ADDRESS: 'address',
+  APP_FACILITY_PROFILE: 'app_facility_profile',
+  BATCHES: 'batches',
+  BUNDLE: 'bundle',
+  BUNDLE_LINES: 'bundle_lines',
+  BUNDLE_RECEIPT_LINES: 'bundle_receipt_lines',
+  BUNDLE_RECEIPTS: 'bundle_receipts',
+  CCEI: 'ccei',
+  CCU: 'ccu',
+  CCU_PROBLEMS: 'ccu_problems',
+  CCU_TEMP_LOG: 'ccu_temp_log',
+  CCU_TYPE: 'ccu_type',
+  COMPANY: 'company',
+  COMPANY_CATEGORY: 'company_category',
+  CURRENCIES: 'currencies',
+  EMPLOYEE: 'employee',
+  EMPLOYEE_CATEGORY: 'employee_category',
+  FACILITY: 'facility',
+  FACILITY_TYPE: 'facility_type',
+  INVENTORY: 'inventory',
+  LOCATIONS: 'locations',
+  MODE_OF_ADMINISTRATION: 'mode_of_administration',
+  ORDERS: 'orders',
+  PRODUCT_CATEGORY: 'product_category',
+  PRODUCT_FORMULATIONS: 'product_formulations',
+  PRODUCT_PRESENTATION: 'product_presentation',
+  PRODUCT_PROFILES: 'product_profiles',
+  PRODUCT_TYPES: 'product_types',
+  PROGRAM_PRODUCTS: 'program_products',
+  PROGRAMS: 'programs',
+  RATE: 'rate',
+  STOCK_OUT: 'stock_out',
+  UOM: 'uom',
+  UOM_CATEGORY: 'uom_category',
+  USER: 'user',
+  USER_RELATED_FACILITIES: 'user_related_facilities'
+});

--- a/app/scripts/services/batchfactory.js
+++ b/app/scripts/services/batchfactory.js
@@ -6,7 +6,7 @@ angular.module('lmisChromeApp')
       function getByUUID(uuid) {
         var deferred = $q.defer();
 
-        storageService.find(storageService.BATCH, uuid).then(function(batch) {
+        storageService.find(storageService.BATCHES, uuid).then(function(batch) {
           var promises = {
             product: productTypeFactory.get(batch.product),
             presentation: presentationFactory.get(batch.presentation),
@@ -39,7 +39,7 @@ angular.module('lmisChromeApp')
       function getBatchesByProductType(productTypeUUID) {
         var deferred = $q.defer(), productTypeBatches = [];
 
-        storageService.all(storageService.BATCH).then(function (data) {
+        storageService.all(storageService.BATCHES).then(function (data) {
 
           angular.forEach(data, function (datum) {
             if (angular.equals(datum.product, productTypeUUID)) {
@@ -69,7 +69,7 @@ angular.module('lmisChromeApp')
           });
         };
 
-        storageService.all(storageService.BATCH).then(function(datum) {
+        storageService.all(storageService.BATCHES).then(function(datum) {
           for(var i = datum.length - 1; i >= 0; i--) {
             if(angular.equals(datum[i].batch_no, batchNo)) {
               resolveBatch(datum[i]);
@@ -87,7 +87,7 @@ angular.module('lmisChromeApp')
       return {
         getAll: function () {
           var deferred = $q.defer(), batches = [];
-          storageService.all(storageService.BATCH).then(function (data) {
+          storageService.all(storageService.BATCHES).then(function (data) {
             angular.forEach(data, function (datum) {
               if (!angular.equals(datum, undefined)) {
                 batches.push(getByUUID(datum.uuid).then(function (batch) {

--- a/app/scripts/services/bundlefactory.js
+++ b/app/scripts/services/bundlefactory.js
@@ -5,7 +5,7 @@ angular.module('lmisChromeApp')
 
       var saveBundleReceipt =  function(bundleReceipt) {
         var deferred = $q.defer(), batches = [];
-        storageService.save(storageService.BUNDLE_RECEIPT, bundleReceipt).then(function (data) {
+        storageService.save(storageService.BUNDLE_RECEIPTS, bundleReceipt).then(function (data) {
           if (data !== undefined) {
             angular.forEach(bundleReceipt.bundle_receipt_lines, function (receiptLine) {
               var newInventory = {
@@ -86,11 +86,11 @@ angular.module('lmisChromeApp')
         var productTypes = {};
         var uomList = {};
 
-        storageService.get(storageService.BATCH).then(function (data) {
+        storageService.get(storageService.BATCHES).then(function (data) {
           batches = data;
         });
 
-        storageService.get(storageService.PROGRAM).then(function (data) {
+        storageService.get(storageService.PROGRAMS).then(function (data) {
           programs = data;
         });
 
@@ -138,11 +138,11 @@ angular.module('lmisChromeApp')
         var uomList = {};
         var bundleLines = [];
 
-        storageService.get(storageService.BATCH).then(function (data) {
+        storageService.get(storageService.BATCHES).then(function (data) {
           batches = data;
         });
 
-        storageService.get(storageService.PROGRAM).then(function (data) {
+        storageService.get(storageService.PROGRAMS).then(function (data) {
           programs = data;
         });
 

--- a/app/scripts/services/ccu-profile-factory.js
+++ b/app/scripts/services/ccu-profile-factory.js
@@ -4,12 +4,12 @@ angular.module('lmisChromeApp').factory('ccuProfileFactory', function ($q, stora
 
   var getByModelId = function (modelId) {
     //TODO: refactor to work with uuid.
-    var ccuProfile = memoryStorageService.get(storageService.CCU_PROFILE, modelId);
+    var ccuProfile = memoryStorageService.get(storageService.CCEI, modelId);
     return ccuProfile;
   };
 
   var getCcuProfiles = function () {
-    var ccuProfileDb = memoryStorageService.getDatabase(storageService.CCU_PROFILE);
+    var ccuProfileDb = memoryStorageService.getDatabase(storageService.CCEI);
     var ccuProfiles = utility.convertObjectToArray(ccuProfileDb);
     return ccuProfiles;
   };

--- a/app/scripts/services/currencyfactory.js
+++ b/app/scripts/services/currencyfactory.js
@@ -4,7 +4,7 @@ angular.module('lmisChromeApp')
     .factory('currencyFactory', function ($q, storageService) {
       function getByUUID(uuid) {
         var deferred = $q.defer();
-        storageService.find(storageService.CURRENCY, uuid).then(function (data) {
+        storageService.find(storageService.CURRENCIES, uuid).then(function (data) {
           deferred.resolve(data);
         });
         return deferred.promise;

--- a/app/scripts/services/formulationfactory.js
+++ b/app/scripts/services/formulationfactory.js
@@ -3,13 +3,13 @@
 angular.module('lmisChromeApp').factory('formulationFactory', function ($q, storageService) {
 
   var getByUuid = function(uuid) {
-    return storageService.find(storageService.PRODUCT_FORMULATION, uuid);
+    return storageService.find(storageService.PRODUCT_FORMULATIONS, uuid);
   };
 
   var getAll = function(){
     var deferred = $q.defer();
     var promises = [];
-    storageService.all(storageService.PRODUCT_FORMULATION)
+    storageService.all(storageService.PRODUCT_FORMULATIONS)
         .then(function(result){
           for(var index in result){
             var formulation = result[index];

--- a/app/scripts/services/product-profile-factory.js
+++ b/app/scripts/services/product-profile-factory.js
@@ -5,7 +5,7 @@ angular.module('lmisChromeApp')
 
     var getByUuid = function(uuid) {
       uuid = utility.getStringUuid(uuid);
-      var prodProfile = memoryStorageService.get(storageService.PRODUCT_PROFILE, uuid);
+      var prodProfile = memoryStorageService.get(storageService.PRODUCT_PROFILES, uuid);
       if(typeof prodProfile === 'object'){
         prodProfile.presentation = presentationFactory.get(prodProfile.presentation);
         prodProfile.product = productTypeFactory.get(prodProfile.product);
@@ -17,7 +17,7 @@ angular.module('lmisChromeApp')
     };
 
     var getAll = function() {
-      var prodProfileDb = memoryStorageService.getDatabase(storageService.PRODUCT_PROFILE);
+      var prodProfileDb = memoryStorageService.getDatabase(storageService.PRODUCT_PROFILES);
       var productProfiles = [];
       for(var key in prodProfileDb){
         var prodProfile = getByUuid(key);
@@ -57,7 +57,7 @@ angular.module('lmisChromeApp')
     };
 
     var getAllGroupedByProductCategory = function(){
-      var db = memoryStorageService.getDatabase(storageService.PRODUCT_PROFILE);
+      var db = memoryStorageService.getDatabase(storageService.PRODUCT_PROFILES);
       var keys = Object.keys(db);
       return getBatchGroupedByProductCategory(keys);
     };

--- a/app/scripts/services/programsfactory.js
+++ b/app/scripts/services/programsfactory.js
@@ -12,7 +12,7 @@ angular.module('lmisChromeApp')
         //TODO: replace nested attributes such as partners, parent with their complete JSON object(Jideobi)
       function getByUUID(uuid) {
         var deferred = $q.defer();
-        storageService.find(storageService.PROGRAM, uuid).then(function (data) {
+        storageService.find(storageService.PROGRAMS, uuid).then(function (data) {
           var program = data;
           deferred.resolve(program);
         });
@@ -22,7 +22,7 @@ angular.module('lmisChromeApp')
       function getAllProgram() {
         var deferred = $q.defer(), programs = [];
 
-        storageService.all(storageService.PROGRAM).then(function (data) {
+        storageService.all(storageService.PROGRAMS).then(function (data) {
           angular.forEach(data, function (datum) {
             programs.push(getByUUID(datum.uuid).then(function (program) {
               deferred.notify(datum);

--- a/app/scripts/services/storage-service.js
+++ b/app/scripts/services/storage-service.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('lmisChromeApp')
-    .factory('storageService', function ($q, $rootScope, $http, $window, chromeStorageApi, utility) {
+    .factory('storageService', function ($q, $rootScope, $http, $window, chromeStorageApi, utility, collections) {
 
       /**
        *  Global variables used to define table names, with this there will be one
@@ -11,76 +11,14 @@ angular.module('lmisChromeApp')
        *  folder that holds data used to pre-fill local storage if it is empty.
        *
        */
-      var productTypes = 'product_types';
-      var productCategory = 'product_category';
-      var address = 'address';
-      var uom = 'uom';
-      var uomCategory = 'uom_category';
-      var facility = 'facility';
-      var program = 'programs';
-      var programProducts = 'program_products';
-      var facilityType = 'facility_type';
-      var employeeCategory = 'employee_category';
-      var company = 'company';
-      var companyCategory = 'company_category';
-      var currency = 'currencies';
-      var employee = 'employee';
-      var rate = 'rate';
-      var ccuType = 'ccu_type';
-      var ccu = 'ccu';
-      var user = 'user';
-      var productPresentation = 'product_presentation';
-      var productFormulation = 'product_formulations';
-      var modeOfAdministration = 'mode_of_administration';
-      var batches = 'batches';
-      var ccuProblem = 'ccu_problems';
-      var ccuTemperatureLog = 'ccu_temp_log';
-      var productProfile = 'product_profiles';
-      var inventory = 'inventory';
-      var orders = 'orders';
-      var bundles = 'bundle';
-      var bundleLines = 'bundle_lines';
-      var bundleReceipt = 'bundle_receipts';
-      var bundleReceiptLines = 'bundle_receipt_lines';
-      var locations = 'locations';
       var stockCount = 'stockcount';
       var discardCount = 'discard_count';
       var appConfig = 'app_config';
-      var stockOut = 'stock_out';
       var surveyResponse = 'survey_response';
-      var ccuProfile = 'ccei';
       var ccuBreakdown = 'ccu_breakdown';
       var pendingSyncs = 'pending_syncs';
 
-    var FIXTURE_NAMES = [
-      productTypes,
-      uom,
-      uomCategory,
-      facility,
-      program,
-      employeeCategory,
-      company,
-      companyCategory,
-      currency,
-      ccuType,
-      ccu,
-      inventory,
-      ccuProblem,
-      user,
-      productCategory,
-      productPresentation,
-      productProfile,
-      productFormulation,
-      modeOfAdministration,
-      batches,
-      orders,
-      bundles,
-      bundleLines,
-      bundleReceipt,
-      locations,
-      stockOut,
-      ccuProfile
-    ];
+      var FIXTURE_NAMES = utility.values(collections);
 
       /**
        * Add new table data to the chrome store.
@@ -383,7 +321,7 @@ angular.module('lmisChromeApp')
         return deferred.promise;
       };
 
-      return {
+      var api = {
         all: getAllFromTable,
         add: setData,
         get: getData,
@@ -399,47 +337,14 @@ angular.module('lmisChromeApp')
         find: getFromTableByKey,
         insertBatch: insertBatch,
         getDateTime: getDateTime,
-        PRODUCT_TYPES: productTypes,
-        PRODUCT_CATEGORY: productCategory,
-        ADDRESS: address,
-        UOM: uom,
-        UOM_CATEGORY: uomCategory,
-        FACILITY: facility,
-        PROGRAM: program,
-        PROGRAM_PRODUCTS: programProducts,
-        FACILITY_TYPE: facilityType,
-        EMPLOYEE_CATEGORY: employeeCategory,
-        COMPANY: company,
-        COMPANY_CATEGORY: companyCategory,
-        CURRENCY: currency,
-        EMPLOYEE: employee,
-        RATE: rate,
-        CCU_TYPE: ccuType,
-        CCU: ccu,
-        USER: user,
-        PRODUCT_PRESENTATION: productPresentation,
-        PRODUCT_FORMULATION: productFormulation,
-        MODE_OF_ADMINISTRATION: modeOfAdministration,
-        BATCH: batches,
-        CCU_PROBLEM: ccuProblem,
-        CCU_TEMPERATURE_LOG: ccuTemperatureLog,
-        PRODUCT_PROFILE: productProfile,
-        INVENTORY: inventory,
-        ORDERS: orders,
-        BUNDLE: bundles,
-        BUNDLE_LINES: bundleLines,
-        BUNDLE_RECEIPT: bundleReceipt,
-        BUNDLE_RECEIPT_LINES: bundleReceiptLines,
-        LOCATIONS: locations,
-        STOCK_COUNT: stockCount,
-        DISCARD_COUNT: discardCount,
         APP_CONFIG: appConfig,
-        STOCK_OUT: stockOut,
-        SURVEY_RESPONSE: surveyResponse,
-        CCU_PROFILE: ccuProfile,
         CCU_BREAKDOWN: ccuBreakdown,
+        DISCARD_COUNT: discardCount,
         PENDING_SYNCS: pendingSyncs,
+        STOCK_COUNT: stockCount,
+        SURVEY_RESPONSE: surveyResponse,
         FIXTURE_NAMES: FIXTURE_NAMES
       };
 
+      return angular.extend(api, collections);
     });

--- a/app/scripts/services/utility.js
+++ b/app/scripts/services/utility.js
@@ -196,4 +196,14 @@ angular.module('lmisChromeApp')
 
     };
 
+    this.values = function(obj) {
+      var values = [];
+      for (var key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+          values.push(obj[key]);
+        }
+      }
+      return values;
+    };
+
   });

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {},
   "devDependencies": {
+    "change-case": "^2.1.1",
     "eslint-no-exclusive-tests": "^0.1.0",
     "grunt": "~0.4.2",
     "grunt-autoprefixer": "~0.7.2",

--- a/tasks/fixtures.js
+++ b/tasks/fixtures.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var path = require('path');
+var changeCase = require('change-case');
+
+module.exports = function(grunt) {
+
+  var collections = {};
+
+  grunt.registerMultiTask('fixtures', 'Load fixtures', function() {
+    var options = this.options({
+      dest: ''
+    });
+
+    this.files.forEach(function(filePair) {
+      filePair.src.forEach(function(src) {
+        var basename = path.basename(src, '.json');
+        var constant = changeCase.constantCase(basename);
+        collections[constant] = basename;
+      });
+    });
+
+    if (options.dest) {
+      collections = JSON.stringify(collections, null, 2);
+      grunt.file.write(options.dest, collections);
+      grunt.log.writeln('Wrote collections at ' + options.dest.cyan);
+
+      grunt.config('ngconstant.fixtures', {
+        options: {
+          name: 'db',
+          dest: options.dest
+        },
+        constants: {
+          collections: grunt.file.readJSON(options.dest)
+        }
+      });
+      grunt.task.run('ngconstant:fixtures');
+    }
+  });
+};

--- a/test/spec/services/product-profile-factory-spec.js
+++ b/test/spec/services/product-profile-factory-spec.js
@@ -49,13 +49,13 @@ describe('Factory: productProfileFactory', function () {
     expect(memoryStorageService.get).not.toHaveBeenCalled();
     var uuid = '075bd789-4b29-4033-80b6-4f834e602628';//BCG 20
     productProfileFactory.get(uuid);
-    expect(memoryStorageService.get).toHaveBeenCalledWith(storageService.PRODUCT_PROFILE, uuid);
+    expect(memoryStorageService.get).toHaveBeenCalledWith(storageService.PRODUCT_PROFILES, uuid);
   });
 
   it('i expect productProfileFactory.get() to return product profile if record exist.', function () {
     var uuid = '075bd789-4b29-4033-80b6-4f834e602628';//BCG 20
     var result = productProfileFactory.get(uuid);
-    var expectedResult = memoryStore[storageService.PRODUCT_PROFILE][uuid];
+    var expectedResult = memoryStore[storageService.PRODUCT_PROFILES][uuid];
     expect(result).toBeDefined();
     expect(result).toEqual(expectedResult);
   });
@@ -63,7 +63,7 @@ describe('Factory: productProfileFactory', function () {
   it('i expect productProfileFactory.getAll() to call memoryStorageService.getDatabase() with the right parameter.', function () {
     expect(memoryStorageService.getDatabase).not.toHaveBeenCalled();
     productProfileFactory.getAll();
-    expect(memoryStorageService.getDatabase).toHaveBeenCalledWith(storageService.PRODUCT_PROFILE);
+    expect(memoryStorageService.getDatabase).toHaveBeenCalledWith(storageService.PRODUCT_PROFILES);
   });
 
   it('i expect productProfileFactory.getAll() to return an array of product profile.', function () {


### PR DESCRIPTION
- Moves DB/collection list into its own module
- Generate module using `grunt fixtures`
- Rename some collection constants where pluralisation differs to filename
- Maintain storage service's public API as a stop-gap until further refactors
- Commit module as tests rely on it (for now)
