### PR TITLE
Check all unused args, closes item:731

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,5 +53,8 @@ rules:
   no-eq-null: 2
   no-floating-decimal: 2
   radix: 2
+  no-unused-vars:
+    - 2
+    - {vars: all, args: all}
   # Custom rules
   no-exclusive-tests: 2


### PR DESCRIPTION
``` js
function($log, $window) {
  $window.a = '';
}
```

… will throw an "unused `$log` warning".
