### PR TITLE
Update build to use CCA v0.1.1, closes item:724

### DIFF
--- a/app/manifest.mobile.json
+++ b/app/manifest.mobile.json
@@ -1,4 +1,5 @@
 {
   "packageId": "com.ehealthafrica.lomis",
-  "versionCode": 32
+  "versionCode": 32,
+  "webview": "system"
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,7 +15,7 @@ info "Performing $type build"
 [[ "$TRAVIS_TAG" ]] && grunt build:release || grunt build
 
 info "Building Mobile Chrome App"
-have "cca" || npm install -g cca@0.1.0
+have "cca" || npm install -g cca@0.1.1
 have "android" || error "Android SDK required"
 
 [[ -d "$build/$app" ]] && rm -rf "$build/$app"
@@ -38,11 +38,11 @@ if [[ "$TRAVIS_TAG" ]]; then
   echo -e "Host $eha\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
   scp -r travisci@$eha:android-keystore/\* "$android"
   cca build --release
-  apk="$android/ant-build/LoMIS-release.apk"
+  apk="$android/bin/LoMIS-release.apk"
   out="$releases/$app-$TRAVIS_TAG.apk"
 else
   cca build
-  apk="$android/ant-build/LoMIS-debug.apk"
+  apk="$android/bin/LoMIS-debug.apk"
   now="$(date -u +"%Y%m%d%H%M%S")"
   out="$snapshots/$app-$now.apk"
 fi

--- a/scripts/build/cca-plugins.txt
+++ b/scripts/build/cca-plugins.txt
@@ -2,4 +2,3 @@ https://git-wip-us.apache.org/repos/asf/cordova-plugin-vibration.git
 https://git-wip-us.apache.org/repos/asf/cordova-plugin-dialogs.git
 https://github.com/vliesaputra/DeviceInformationPlugin
 https://github.com/aharris88/phonegap-sms-plugin.git
-https://git-wip-us.apache.org/repos/asf/cordova-plugin-geolocation.git


### PR DESCRIPTION
- CCA now installs geolocation plugin itself (if permission is set in manifest)
- Disable new Crosswalk webview until build size is reduced
- Retain version lock to prevent possible future broken builds
