### PR TITLE
Angular v1.2.20 support, closes item:783

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,11 +1,12 @@
 <!doctype html>
-<html ng-app="lmisChromeApp">
+<html ng-app="lmisChromeApp" ng-csp>
 <head>
   <meta charset="utf-8">
   <title>Nigeria LMIS</title>
   <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height">
   <!-- build:css styles/vendor.css -->
   <!-- bower:css -->
+  <link rel="stylesheet" href="bower_components/angular/angular-csp.css" />
   <link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.css" />
   <link rel="stylesheet" href="bower_components/bootstrap-css-only/css/bootstrap.css" />
   <link rel="stylesheet" href="bower_components/bootstrap-theme-cosmo/cosmo.min.css" />

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "lmis-chrome",
   "version": "0.10.4",
   "dependencies": {
-    "angular": "1.2.19",
+    "angular": "~1.2.20",
     "angular-bootstrap": "~0.11.0",
     "font-awesome": "~4.1.0",
     "angular-ui-router": "~0.2.10",
@@ -12,11 +12,11 @@
     "bootstrap-theme-cosmo": "tlvince/bootstrap-theme-cosmo#4c161a6bf5bebe0ecfbef0771e053c8c5c2698c9",
     "angularjs-nvd3-directives": "~0.0.7",
     "angular-growl-v2": "~0.6.1",
-    "angular-animate": "1.2.19",
+    "angular-animate": "~1.2.20",
     "chrome-platform-analytics": "GoogleChrome/chrome-platform-analytics#ea84600d1251fee9dd3fe274780f385d5d1c03f1"
   },
   "devDependencies": {
-    "angular-mocks": "1.2.19",
+    "angular-mocks": "~1.2.20",
     "jasmine-as-promised": "~0.0.8",
     "es5-shim": "~3.4.0"
   },
@@ -36,5 +36,13 @@
   "private": true,
   "resolutions": {
     "d3": "~3.4.1"
+  },
+  "overrides": {
+    "angular": {
+      "main": [
+        "angular.js",
+        "angular-csp.css"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Manually enable Angular CSP mode as auto-detection triggers a harmless, though
nonetheless annoying CSP error.

CSP detection has also proved to be brittle.

Override Angular's Bower main block to include `angular-csp.css` so that Wiredep
can inject it for us.

See: https://github.com/angular/angular.js/pull/8191
