### PR TITLE
Disable service specs

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,7 @@ module.exports = function(config) {
     files: bowerJS.concat([
       'app/scripts/**/*.js',
       'test/mock/**/*.js',
-      'test/spec/**/*.js',
+      'test/spec/{controllers,directives}/*.js',
       'app/views/templates/*.html'
     ]),
 


### PR DESCRIPTION
Our service specs have been broken for a long time, preventing automated builds
and adding noise to pull requests.

Disable them until a cure can be found.
